### PR TITLE
Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,19 @@ Ground is an open source, map-centric data collection platform for occasionally 
 
 This is not an officially supported Google product, and it is currently under development on best-effort basis. Please check back periodically for updates.
 
+You can learn more about Ground on the [project
+website](https://google.github.io/ground-platform).
+
+## About this Repository
+
 This repo contains all Ground cloud-based / hosted components:
 
-|Directory|Component|
-|--------------|-----------------------------------------------|
-|[docs/](docs/)|*Public documentation*, including Ground homepage|
+|Directory               |Component|
+|------------------------|-----------------------------------------------|
+|[docs/](docs/)          |*Public documentation*, including Ground homepage|
 |[firestore/](firestore/)|*Firestore Config* defining Firebase rules and other database settings|
 |[functions/](functions/)|*Firebase Cloud Functions*, used to sync with Google Sheets and import/export data to/from other data sources|
-|[web/](web/)|*Ground Web Console* used to set up and manage projects, and to view, edit, and analyze collected data online|
+|[web/](web/)            |*Ground Web Console* used to set up and manage projects, and to view, edit, and analyze collected data online|
 
 Firestore Cloud Functions currently only supports Node.js v6.11.5, 
 while the web dashboard is built using a newer version of Node.js. Contributors should use the appropriate version of Node for the component they are working on. Follow the instructions provided in the README of each subdirectory to set up the proper

--- a/functions/README.md
+++ b/functions/README.md
@@ -12,9 +12,9 @@ modify, run, and deploy Ground Cloud Functions source code.
 
 ### Node.js 
 
-This guide recommends using Node Version Manager (nvm) to install and manage versions
-of Node.js and assumes nvm is installed. For more information on nvm, as well
-as installation instructions, see: <https://github.com/creationix/nvm#installation>
+> **Note**: This guide recommends using Node Version Manager (nvm) to install and manage versions
+> of Node.js and assumes nvm is installed. For more information on nvm, as well
+> as installation instructions, see: <https://github.com/creationix/nvm#installation>
 
 Firestore Cloud Functions currently require version 6.11.5 of Node.js.
 

--- a/web/README.md
+++ b/web/README.md
@@ -13,9 +13,9 @@ work on Ground Web Console source code.
 
 ### Node.js 
 
-This guide recommends using Node Version Manager (nvm) to install and manage versions
-of Node.js and assumes nvm is installed. For more information on nvm, as well
-as installation instructions, see: <https://github.com/creationix/nvm#installation>
+> **Note**: This guide recommends using Node Version Manager (nvm) to install and manage versions
+> of Node.js and assumes nvm is installed. For more information on nvm, as well
+> as installation instructions, see: <https://github.com/creationix/nvm#installation>
 
 To set up Node.js:
 


### PR DESCRIPTION
Updates the readme files to emphasize NVM. This change only introduces syntactic/visual emphasis. If you think it's worthwhile to emphasize it using structural changes, lmk. I refrained from doing so only because nvm *technically* isn't a requirement, though it is what we're recommending to manage node versions. Also added a link to the docs index to the top level README. I think #37 may simplify this even further?—nvm shouldn't be needed if we can use a single version of node for all our use cases.

Fixes #32 #29 