### PR TITLE
Adjust Site Logo Size

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -25,7 +25,7 @@
     <!--<a id="skip-to-content" href="#content">Skip to the content.</a>-->
 
     <header class="page-header" role="banner">
-      <img src="{{ '/assets/images/ic_launcher_round.png?v=' | append: site.github.build_revision | relative_url }}">
+      <img class="project-logo" src="{{ '/assets/images/ic_launcher_round.png?v=' | append: site.github.build_revision | relative_url }}">
       <h1 class="project-name">{{ site.title | default: site.github.repository_name }}</h1>
       <h2 class="project-tagline">{{ site.description | default: site.github.project_tagline }}</h2>
       {% if site.github.is_project_page %}

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -15,6 +15,7 @@ $font-body: "Lora", serif;
   background-repeat: no-repeat;
   background-position: center;
   background-size: cover;
+  max-height: 400px;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -28,6 +29,11 @@ h1 {
 
 .main-content p {
   font-family: $font-body;
+}
+
+.project-logo {
+  width: 80px;
+  height: 80px;
 }
 
 .project-name {

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -15,7 +15,6 @@ $font-body: "Lora", serif;
   background-repeat: no-repeat;
   background-position: center;
   background-size: cover;
-  max-height: 400px;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -32,8 +31,8 @@ h1 {
 }
 
 .project-logo {
-  width: 80px;
-  height: 80px;
+  width: 120px;
+  height: 120px;
 }
 
 .project-name {


### PR DESCRIPTION
Small change here, I decreased the site's logo size to 120x120. I've attached a screenshot of what it looks like. I've also attached an image of the logo at size 80x80. We can do whatever size seems reasonable, just lmk.

120x120: <img width="1366" alt="screen shot 2019-01-22 at 7 08 23 pm" src="https://user-images.githubusercontent.com/11237600/51573925-738ce380-1e79-11e9-9829-085b30a6a6e3.png">

80x80: <img width="1359" alt="screen shot 2019-01-22 at 7 07 43 pm" src="https://user-images.githubusercontent.com/11237600/51573910-64a63100-1e79-11e9-815c-d8c933852ed8.png">
