### PR TITLE
Warn against unwitting commits in PRs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ submit them to the base repository using a pull request.
 1. Create a [pull request](https://help.github.com/articles/about-pull-requests/) to have your changes reviewed and merged into the base 
 repository. Reference the [issue](https://github.com/google/ground-platform/issues) your changes resolve in either the commit message for your changes or in your pull request. 
 
+    > :exclamation: Any subsequent changes committed to the branch you used
+    > to open your PR are automatically included in the PR. If you've opened a
+    > PR but would like to continue to work on unrelated changes, be sure to
+    > start a new branch to track those changes.
+
     For more information on creating pull requests, see <https://help.github.com/articles/creating-a-pull-request/>. 
     
     To learn more about referencing issues in your pull request or commit messages, see <https://help.github.com/articles/closing-issues-using-keywords/>.


### PR DESCRIPTION
I've added a note warning readers about open PRs and automatic commit inclusion—hopefully this makes it clear. Presumably this is the proper place for it in the flow, as it comes in when the developer has completed a logical group of changes.
