### PR TITLE
Adds icons next to each field type

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9612,6 +9612,11 @@
       "resolved": "https://registry.npmjs.org/mdi-material-ui/-/mdi-material-ui-5.7.0.tgz",
       "integrity": "sha512-rYYldBKvPqbh/DNsv3YFpEOejtgA6PtmdA+BgaXhMqqfniUmhUC2p8jQRmVrEjm6fOjkB3y9irTCAdlcNQzi/w=="
     },
+    "mdi-react": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/mdi-react/-/mdi-react-5.4.0.tgz",
+      "integrity": "sha512-Y4eUHbbEiiQC8og6ofMM7ukUIiD+NnIQRpJHj2aVzle918aUCJh4Du9sjXw+yJ+wi8Nh7TdNvFptJD3WIdlbNw=="
+    },
     "mdn-data": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "history": "^4.7.2",
     "immutability-helper": "^2.8.1",
     "mdi-material-ui": "^5.5.0",
+    "mdi-react": "5.4.0",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "react-google-maps": "^9.4.5",

--- a/web/src/components/gnd-feature-type-editor/gnd-form-element-editor.js
+++ b/web/src/components/gnd-feature-type-editor/gnd-form-element-editor.js
@@ -29,6 +29,9 @@ import {
   FormControlLabel
 } from "@material-ui/core";
 import DeleteForeverIcon from "@material-ui/icons/DeleteForever";
+import CheckBoxMultipleMarked from 'mdi-react/CheckboxMultipleMarkedIcon';
+import CheckCircle from 'mdi-react/CheckCircleIcon';
+import ShortText from 'mdi-react/TextIcon';
 import { getLocalizedText } from "../../datastore.js";
 import GndFocusableRow from "./gnd-focusable-row";
 import GndMultiSelectOptionsEditor from "./gnd-multi-select-options-editor";
@@ -143,9 +146,9 @@ class GndFormElementEditor extends React.Component {
             onChange={ev => this.handleTypeChange(ev.target.value)}
             onBlur={ev => this.handleTypeChange(ev.target.value.trim())}
           >
-            <MenuItem value="text_field">Text</MenuItem>
-            <MenuItem value="select_one">Select one</MenuItem>
-            <MenuItem value="select_multiple">Select multiple</MenuItem>
+            <MenuItem value="text_field"><ShortText style={{ marginRight: 5 }}></ShortText>Text</MenuItem>
+            <MenuItem value="select_one"><CheckCircle style={{ marginRight: 5 }}></CheckCircle>Select one</MenuItem>
+            <MenuItem value="select_multiple"><CheckBoxMultipleMarked style={{ marginRight: 5 }}></CheckBoxMultipleMarked>Select multiple</MenuItem>
           </Select>
         </div>
         {element.type === "multiple_choice" && (

--- a/web/src/components/gnd-feature-type-editor/gnd-form-element-editor.js
+++ b/web/src/components/gnd-feature-type-editor/gnd-form-element-editor.js
@@ -51,6 +51,9 @@ const styles = {
   bottomControls: {
     width: "100%",
     display: "block"
+  },
+  icon: {
+    marginRight: 5
   }
 };
 
@@ -146,9 +149,9 @@ class GndFormElementEditor extends React.Component {
             onChange={ev => this.handleTypeChange(ev.target.value)}
             onBlur={ev => this.handleTypeChange(ev.target.value.trim())}
           >
-            <MenuItem value="text_field"><ShortText style={{ marginRight: 5 }}></ShortText>Text</MenuItem>
-            <MenuItem value="select_one"><CheckCircle style={{ marginRight: 5 }}></CheckCircle>Select one</MenuItem>
-            <MenuItem value="select_multiple"><CheckBoxMultipleMarked style={{ marginRight: 5 }}></CheckBoxMultipleMarked>Select multiple</MenuItem>
+            <MenuItem value="text_field"><ShortText className={classes.icon}></ShortText>Text</MenuItem>
+            <MenuItem value="select_one"><CheckCircle className={classes.icon}></CheckCircle>Select one</MenuItem>
+            <MenuItem value="select_multiple"><CheckBoxMultipleMarked className={classes.icon}></CheckBoxMultipleMarked>Select multiple</MenuItem>
           </Select>
         </div>
         {element.type === "multiple_choice" && (


### PR DESCRIPTION
closes #22

note: mdi-react import used over materialui/icons because the CheckBoxMultipleMarkedIcon is not a part of materialui/icons but is included with mdi-react.