### PR TITLE
Issue 79: Renamed labels to Layer

### DIFF
--- a/web/src/components/gnd-feature-type-editor/index.js
+++ b/web/src/components/gnd-feature-type-editor/index.js
@@ -243,11 +243,8 @@ class GndFeatureTypeEditor extends React.Component<Props> {
                 inputClassName="ft-label-input"
                 onCommitChanges={this.handleFeatureTypeLabelChange.bind(this)}
                 value={featureTypeLabel}
-                placeholder="Unnamed feature type"
+                placeholder="Unnamed layer"
               />
-              <div className="ft-header-caption">
-                <Typography variant="caption">Feature type</Typography>
-              </div>
             </div>
             <GndFormTabs
               formIndex={formIndex}

--- a/web/src/components/gnd-legend/index.js
+++ b/web/src/components/gnd-legend/index.js
@@ -174,7 +174,7 @@ class GndLegend extends React.Component<Props> {
       <Card className={classes.card}>
         <CardContent className={classes.cardContent}>
           <Typography className={classes.heading} color="textSecondary">
-            Legend
+            Layer
           </Typography>
           <List className={classes.list}>
             {featureTypesArray.map(
@@ -184,12 +184,12 @@ class GndLegend extends React.Component<Props> {
             size="small"
             color="default"
             classes={{root: classes.addFeatureTypeBtn}}
-            aria-label="Add feature type"
+            aria-label="Add layer"
             onClick={this.handleAddFeatureTypeClick.bind(this)}
           >
             <Add fontSize="small" color="action" />
             <Typography fontSize="small" color="textSecondary">
-              Add feature type
+              Add layer
             </Typography>
           </Button>
         </CardContent>

--- a/web/src/components/gnd-legend/index.js
+++ b/web/src/components/gnd-legend/index.js
@@ -174,7 +174,7 @@ class GndLegend extends React.Component<Props> {
       <Card className={classes.card}>
         <CardContent className={classes.cardContent}>
           <Typography className={classes.heading} color="textSecondary">
-            Layer
+            Layers
           </Typography>
           <List className={classes.list}>
             {featureTypesArray.map(


### PR DESCRIPTION
Renamed labels "Legend" and "feature type" to "Layer" and removed one "Feature type" heading entirely.