### PR TITLE
Fix bug#94 and change reorder behavior to match UI

### DIFF
--- a/web/src/components/gnd-feature-type-editor/gnd-form-editor.js
+++ b/web/src/components/gnd-feature-type-editor/gnd-form-editor.js
@@ -105,14 +105,13 @@ class GndFormEditor extends React.Component {
   onSortEnd = ({oldIndex, newIndex}) => {
     const {form, onChange} = this.props;
     const oldIndexElement = form.defn.elements[oldIndex];
-    const newIndexElement = form.defn.elements[newIndex];
     onChange(
       update(form, {
         defn: {
-          elements: {
-            [oldIndex]: {$set: newIndexElement},
-            [newIndex]: {$set: oldIndexElement}
-          }
+          elements: {$splice: [
+            [oldIndex, 1],
+            [newIndex, 0, oldIndexElement]
+          ]}
         },
       })
     );

--- a/web/src/components/gnd-feature-type-editor/gnd-form-editor.js
+++ b/web/src/components/gnd-feature-type-editor/gnd-form-editor.js
@@ -17,18 +17,13 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import GndFormElementEditor from './gnd-form-element-editor';
 import GndFormWarning from './gnd-form-warning';
 import update from 'immutability-helper';
-import {Add, DragHandle} from '@material-ui/icons';
+import {Add} from '@material-ui/icons';
 import Button from '@material-ui/core/Button';
 import {withStyles} from '@material-ui/core/styles';
 import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
-import {
-  sortableContainer,
-  sortableElement,
-  sortableHandle,
-} from 'react-sortable-hoc';
+import {GndSortableContainer, GndSortableElement} from './gnd-sortable';
 
 const styles = (theme) => ({
   button: {
@@ -50,19 +45,6 @@ const styles = (theme) => ({
   bottomControls: {
     display: 'block',
     width: '100%',
-  },
-  sortableElement: {
-    zIndex: 1300,
-    '&:hover div[name=sortableHandle]': {
-      visibility: 'visible',
-    }
-  },
-  sortableHandle: {
-    textAlign: 'center',
-    visibility: 'hidden',
-    '&:hover': {
-      cursor: 'move',
-    }
   }
 });
 
@@ -142,43 +124,22 @@ class GndFormEditor extends React.Component {
       return null;
     }
     
-    const SortableHandle = sortableHandle(() =>
-      <div className={classes.sortableHandle} name="sortableHandle">
-        <DragHandle fontSize="inherit"/>
-      </div>
-    );
-
-    const SortableElement = sortableElement(({element, onChange}) =>
-      <div className={classes.sortableElement}>
-        <SortableHandle />
-        <GndFormElementEditor
-          key={element.id}
-          element={element}
-          onChange={onChange}
-        />
-      </div>
-    );
-
-    const SortableContainer = sortableContainer(({children}) => 
-      <div>{children}</div>
-    );
-    
     return (
       <React.Fragment>
-        <SortableContainer
+        <GndSortableContainer
           onSortEnd={this.onSortEnd}
           lockAxis='y'
           useDragHandle
         >
           {form.defn.elements.map((element, index) => (
-            <SortableElement
+            <GndSortableElement
               key={`item-${index}`}
               index={index}
               element={element}
               onChange={(el) => this.handleElementChange(el, index)}
             />
           ))}
-        </SortableContainer>
+        </GndSortableContainer>
         <div className={classes.bottomControls}>
           <span className={classes.bottomLeftControls}>
             <Button

--- a/web/src/components/gnd-feature-type-editor/gnd-sortable.js
+++ b/web/src/components/gnd-feature-type-editor/gnd-sortable.js
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import GndFormElementEditor from './gnd-form-element-editor';
+import {DragHandle} from '@material-ui/icons';
+import {withStyles} from '@material-ui/core/styles';
+import {
+  sortableContainer,
+  sortableElement,
+  sortableHandle,
+} from 'react-sortable-hoc';
+
+const styles = {
+  sortableHandle: {
+    textAlign: 'center',
+    visibility: 'hidden',
+    '&:hover': {
+      cursor: 'move',
+    }
+  },
+  sortableElement: {
+    zIndex: 1300,
+    '&:hover div[name=sortableHandle]': {
+      visibility: 'visible',
+    }
+  }
+};
+
+const GndSortableHandle = withStyles(styles)(sortableHandle(({classes}) =>
+  <div className={classes.sortableHandle} name="sortableHandle">
+    <DragHandle fontSize="inherit"/>
+  </div>
+));
+
+class GndElement extends React.Component {
+  render() {
+    const {element, onChange, classes} = this.props;
+    return (
+      <div className={classes.sortableElement}>
+        <GndSortableHandle />
+        <GndFormElementEditor
+          element={element}
+          onChange={onChange}
+        />
+      </div>
+    );
+  }
+}
+
+const GndSortableElement = sortableElement(withStyles(styles)(GndElement));
+
+const GndSortableContainer = sortableContainer(({children}) => 
+  <div>{children}</div>
+);
+
+export {GndSortableElement, GndSortableContainer}

--- a/web/src/components/gnd-feature-type-editor/gnd-sortable.js
+++ b/web/src/components/gnd-feature-type-editor/gnd-sortable.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2018 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
For bug#94, somehow using component class instead of functional component prevents other elements in SortableContainer from re-rendering. Might be a weird behavior in react-sortable-hoc.

Sneaking another bug fix (2nd commit) found during fixing bug#94:  change reorder logic from 'swap idxA idxB' to 'remove idxA then insert it back at idxB' so that it matches what renders in UI.