### PR TITLE
Configure Prettier using `npx gts init`

### DIFF
--- a/web-ng/package-lock.json
+++ b/web-ng/package-lock.json
@@ -2810,9 +2810,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.11.tgz",
-      "integrity": "sha512-O+x6uIpa6oMNTkPuHDa9MhMMehlxLAd5QcOvKRjAFsBVpeFWTOPnXbDvILvFgFFZfQ1xh1EZi1FbXxUix+zpsQ==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.3.tgz",
+      "integrity": "sha512-J7nx6JzxmtT4zyvfLipYL7jNaxvlCWpyG7JhhCQ4fQyG+AGfovAHoYR55TFx+X8akfkUJYpt5JG6GPeFMjZaCQ==",
       "dev": true
     },
     "@types/q": {

--- a/web-ng/package.json
+++ b/web-ng/package.json
@@ -51,6 +51,7 @@
     "protractor": "5.4.0",
     "ts-node": "7.0.0",
     "tslint": "5.15.0",
-    "typescript": "3.5.3"
+    "typescript": "3.5.3",
+    "@types/node": "10.0.3"
   }
 }

--- a/web-ng/prettier.config.js
+++ b/web-ng/prettier.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  singleQuote: true,
+  trailingComma: 'es5',
+};


### PR DESCRIPTION
This allows Prettier formatter to run using GTS style in supported editors.