### PR TITLE
[Auth] Create user profile server-side instead of client-side

### DIFF
--- a/functions/common/datastore.js
+++ b/functions/common/datastore.js
@@ -14,20 +14,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 'use strict';
 
 class Datastore {
   constructor(db) {
     this.db_ = db;
-  }  
+  }
+
+  /**
+   * Stores user email, name, and avatar to db for use in application features.
+   * These attributes are merged with other existing ones if already present.
+   */
+  mergeUserProfile({uid, email, displayName, photoURL}) {
+    return this.db_.doc(`users/${uid}`)
+        .set({uid, email, displayName, photoURL}, {merge: true});
+  }
 
   fetch_(docRef) {
     return docRef.get().then(doc => doc.exists ? doc.data() : null);
   }
 
   fetchDoc_(path) {
-    return this.fetch_(this.db_.doc(path));    
+    return this.fetch_(this.db_.doc(path));
   }
 
   fetchCollection_(path) {
@@ -39,7 +48,8 @@ class Datastore {
   }
 
   fetchRecord(projectId, featureId, recordId) {
-    return this.fetchDoc_(`projects/${projectId}/features/${featureId}/records/${recordId}`);
+    return this.fetchDoc_(
+        `projects/${projectId}/features/${featureId}/records/${recordId}`);
   }
 
   fetchRecords(projectId, featureId) {
@@ -55,7 +65,8 @@ class Datastore {
   }
 
   fetchForm(projectId, featureTypeId, formId) {
-    return this.fetchDoc_(`projects/${projectId}/featureTypes/${featureTypeId}/forms/${formId}`);
+    return this.fetchDoc_(
+        `projects/${projectId}/featureTypes/${featureTypeId}/forms/${formId}`);
   }
 
   fetchSheetsConfig(projectId) {

--- a/functions/index.js
+++ b/functions/index.js
@@ -42,10 +42,7 @@ exports.updateColumns = functions.https.onRequest(
         updateColumns(req, res).catch(err => res.status(500).send(`${err}`)));
 
 // Test via shell:
-// onCreateRecord({featureTypeId: 'households', formId: '1',
-// responses: {'interviewer': 'Nikola Tesla'}}, {params: {projectId:
-// 'R06MucQJSWvERdE7SiL1', featureId: 'p9lyePfXYPOByUFpnIVp', recordId:
-// 'newRecord'}});
+// onCreateRecord({featureTypeId: 'households', formId: '1', responses: {'interviewer': 'Nikola Tesla'}}, {params: {projectId: 'R06MucQJSWvERdE7SiL1', featureId: 'p9lyePfXYPOByUFpnIVp', recordId: 'newRecord'}});
 exports.onCreateRecord =
     functions.firestore
         .document(
@@ -53,10 +50,7 @@ exports.onCreateRecord =
         .onCreate((change, context) => onCreateRecord(change, context));
 
 // Test via shell:
-// onUpdateRecord({after: {featureTypeId: 'households', formId: '1',
-// responses: {'interviewer': 'George Washington'}}}, {params: {projectId:
-// 'R06MucQJSWvERdE7SiL1', featureId: 'p9lyePfXYPOByUFpnIVp', recordId:
-// 'newRecord'}});
+// onUpdateRecord({after: {featureTypeId: 'households', formId: '1', responses: {'interviewer': 'George Washington'}}}, {params: {projectId: 'R06MucQJSWvERdE7SiL1', featureId: 'p9lyePfXYPOByUFpnIVp', recordId: 'newRecord'}});
 exports.onUpdateRecord =
     functions.firestore
         .document(

--- a/functions/index.js
+++ b/functions/index.js
@@ -14,34 +14,51 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 'use strict';
 
 const functions = require('firebase-functions');
+const onCreateUser = require('./on-create-user')
 const exportCsv = require('./export-csv')
 const exportKml = require('./export-kml')
 const updateColumns = require('./update-columns')
 const onCreateRecord = require('./on-create-record')
 const onUpdateRecord = require('./on-update-record')
 
-exports.exportCsv = functions.https.onRequest((req, res) =>
-	exportCsv(req, res).catch(err => res.status(500).send(`${err}`)));
-exports.exportKml = functions.https.onRequest((req, res) =>
-	exportKml(req, res).catch(err => res.status(500).send(`${err}`)));
+// Create user profile in database when user first logs in.
+exports.onCreateUser = functions.auth.user().onCreate(onCreateUser);
+
+exports.exportCsv = functions.https.onRequest(
+    (req, res) =>
+        exportCsv(req, res).catch(err => res.status(500).send(`${err}`)));
+exports.exportKml = functions.https.onRequest(
+    (req, res) =>
+        exportKml(req, res).catch(err => res.status(500).send(`${err}`)));
 
 // Test via shell:
 // updateColumns.get('/?project=R06MucQJSWvERdE7SiL1&featureType=aaaaaaaa&form=1234567')
-exports.updateColumns = functions.https.onRequest((req, res) => 
-  updateColumns(req, res).catch(err => res.status(500).send(`${err}`)));
+exports.updateColumns = functions.https.onRequest(
+    (req, res) =>
+        updateColumns(req, res).catch(err => res.status(500).send(`${err}`)));
 
 // Test via shell:
-// onCreateRecord({featureTypeId: 'households', formId: '1', responses: {'interviewer': 'Nikola Tesla'}}, {params: {projectId: 'R06MucQJSWvERdE7SiL1', featureId: 'p9lyePfXYPOByUFpnIVp', recordId: 'newRecord'}});
-exports.onCreateRecord = functions.firestore
-  .document('projects/{projectId}/features/{featureId}/records/{recordId}')
-  .onCreate((change, context) => onCreateRecord(change, context));
+// onCreateRecord({featureTypeId: 'households', formId: '1',
+// responses: {'interviewer': 'Nikola Tesla'}}, {params: {projectId:
+// 'R06MucQJSWvERdE7SiL1', featureId: 'p9lyePfXYPOByUFpnIVp', recordId:
+// 'newRecord'}});
+exports.onCreateRecord =
+    functions.firestore
+        .document(
+            'projects/{projectId}/features/{featureId}/records/{recordId}')
+        .onCreate((change, context) => onCreateRecord(change, context));
 
 // Test via shell:
-// onUpdateRecord({after: {featureTypeId: 'households', formId: '1', responses: {'interviewer': 'George Washington'}}}, {params: {projectId: 'R06MucQJSWvERdE7SiL1', featureId: 'p9lyePfXYPOByUFpnIVp', recordId: 'newRecord'}});
-exports.onUpdateRecord = functions.firestore
-  .document('projects/{projectId}/features/{featureId}/records/{recordId}')
-  .onUpdate((change, context) => onUpdateRecord(change, context));
+// onUpdateRecord({after: {featureTypeId: 'households', formId: '1',
+// responses: {'interviewer': 'George Washington'}}}, {params: {projectId:
+// 'R06MucQJSWvERdE7SiL1', featureId: 'p9lyePfXYPOByUFpnIVp', recordId:
+// 'newRecord'}});
+exports.onUpdateRecord =
+    functions.firestore
+        .document(
+            'projects/{projectId}/features/{featureId}/records/{recordId}')
+        .onUpdate((change, context) => onUpdateRecord(change, context));

--- a/functions/on-create-user.js
+++ b/functions/on-create-user.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {db} = require('./common/context');
+
+/**
+ * Called when a new user logs in for the first time.
+ */
+module.exports = user => db.mergeUserProfile(user);

--- a/web-ng/src/app/services/auth/auth.service.ts
+++ b/web-ng/src/app/services/auth/auth.service.ts
@@ -46,11 +46,7 @@ export class AuthService {
 
   async signIn() {
     const provider = new auth.GoogleAuthProvider();
-    const credential = await this.afAuth.auth.signInWithPopup(provider);
-    // If sign in succeeds, write user details to database.
-    if (credential.user) {
-      return this.dataStore.updateUser$(credential.user as User);
-    }
+    await this.afAuth.auth.signInWithPopup(provider);
   }
 
   async signOut() {

--- a/web-ng/src/app/services/data-store/data-store.service.ts
+++ b/web-ng/src/app/services/data-store/data-store.service.ts
@@ -55,22 +55,4 @@ export class DataStoreService {
   user$(uid: string): Observable<User | undefined> {
     return this.db.doc<User>(`users/${uid}`).valueChanges();
   }
- 
-  /**
-   * Store user email, name, and avatar to db for use in application features.
-   * These attributes are merged with other existing ones if they were added
-   * by other clients.
-   */
-   updateUser$({ uid, email, displayName, photoURL }: User) {
-    // TODO: Move into Cloud Function so this works for all clients.
-    this.db.doc(`users/${uid}`).set(
-      {
-        uid,
-        email,
-        displayName,
-        photoURL,
-      },
-      { merge: true }
-    );
-  }
 }


### PR DESCRIPTION
Writes user profile data to `/user/{uid}` in Cloud Firestore.

Since admin user is now used to create user profile, user does't need permission to write to it directly, simplifying permissions model.

This also now causes profiles to be created for users who first sign in using Android app.