### PR TITLE
Add suffix to url in README.md

### DIFF
--- a/web-ng/README.md
+++ b/web-ng/README.md
@@ -74,8 +74,10 @@ This last step will fail if you haven't yet following instructions above in
 
 ## Development server
 
-Run `ng serve` for a dev server. Navigate to http://localhost:4200/. The app
-will automatically reload if you change any of the source files.
+Run `ng serve` for a dev server. Navigate to http://localhost:4200/. Add 
+`p/<project_name>` as a suffix to the url to see the map interface in your 
+browser (e.g. http://localhost:4200/p/new).
+The app will automatically reload if you change any of the source files.
 
 ## Code scaffolding
 


### PR DESCRIPTION
Add "/p/new" suffix to http://localhost:4200/ in README.md of web-ng folder to see the map UI, otherwise a blank page is shown.