### PR TITLE
Add authentication methods to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,11 +99,11 @@ submit them to the base repository using a pull request.
     
     Where `<branch>` is the branch name you used in step 2.
 
-    If asked for github username and password, make sure to use your [Personal
-    Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) instead of your password, since two-factor authentication is
-    enabled by default.
+    Note (Googlers-only): If asked for github username and password, make sure
+    to use your [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) instead of your password, since two-factor 
+    authentication is enabled by default for accounts associated with Google.
 
-    Alternatively, one can [connect to GitHub via SSH](https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh) instead of HTTPS and use
+    Alternatively, you can [connect to GitHub via SSH](https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh) instead of HTTPS and use
     a public/private key pair for authentication.
 
 1. Create a [pull request](https://help.github.com/articles/about-pull-requests/) to have your changes reviewed and merged into the base 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,10 @@ submit them to the base repository using a pull request.
     
     Where `<branch>` is the branch name you used in step 2.
 
+    If asked for github username and password, make sure to use your [Personal
+    Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) instead of your password, since two-factor authentication is
+    enabled by default.
+
 1. Create a [pull request](https://help.github.com/articles/about-pull-requests/) to have your changes reviewed and merged into the base 
 repository. Reference the [issue](https://github.com/google/ground-platform/issues) your changes resolve in either the commit message for your changes or in your pull request. 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,9 +99,9 @@ submit them to the base repository using a pull request.
     
     Where `<branch>` is the branch name you used in step 2.
 
-    Note (Googlers-only): If asked for github username and password, make sure
-    to use your [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) instead of your password, since two-factor 
-    authentication is enabled by default for accounts associated with Google.
+    **Note**: If you have two factor authentication enabled, make sure to use
+    your [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) instead of your password.
+
 
     Alternatively, you can [connect to GitHub via SSH](https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh) instead of HTTPS and use
     a public/private key pair for authentication.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,9 @@ submit them to the base repository using a pull request.
     Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) instead of your password, since two-factor authentication is
     enabled by default.
 
+    Alternatively, one can [connect to GitHub via SSH](https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh) instead of HTTPS and use
+    a public/private key pair for authentication.
+
 1. Create a [pull request](https://help.github.com/articles/about-pull-requests/) to have your changes reviewed and merged into the base 
 repository. Reference the [issue](https://github.com/google/ground-platform/issues) your changes resolve in either the commit message for your changes or in your pull request. 
 

--- a/web-ng/README.md
+++ b/web-ng/README.md
@@ -74,8 +74,10 @@ This last step will fail if you haven't yet following instructions above in
 
 ## Development server
 
-Run `ng serve` for a dev server. Navigate to http://localhost:4200/. The app
-will automatically reload if you change any of the source files.
+Run `ng serve` for a dev server. Navigate to http://localhost:4200/. Add 
+`p/<project_name>` as a suffix to the url to see the map interface in your 
+browser (e.g. http://localhost:4200/p/new).
+The app will automatically reload if you change any of the source files.
 
 ## Code scaffolding
 

--- a/web-ng/README.md
+++ b/web-ng/README.md
@@ -75,8 +75,9 @@ This last step will fail if you haven't yet following instructions above in
 ## Development server
 
 Run `ng serve` for a dev server. Navigate to http://localhost:4200/. Add 
-`p/<project_name>` as a suffix to the url to see the map interface in your 
-browser (e.g. http://localhost:4200/p/new).
+`p/<project_name>` as a suffix to the url to see an existing project interface
+in your browser. Alternatively, go to http://localhost:4200/p/:new for a
+new project. 
 The app will automatically reload if you change any of the source files.
 
 ## Code scaffolding


### PR DESCRIPTION
Add authentication methods to CONTRIBUTING.md, since two-step verification is enabled by default for us, it is not trivial to use PAT instead of GitHub password. Another possibility would also be to use SSH.