### PR TITLE
Integrate Angular Material themes into several components

### DIFF
--- a/web-ng/angular.json
+++ b/web-ng/angular.json
@@ -25,7 +25,7 @@
             ],
             "styles": [
               "src/custom-theme.scss",
-              "src/styles.css"
+              "src/styles.scss"
             ],
             "scripts": []
           },
@@ -90,7 +90,7 @@
               "src/assets"
             ],
             "styles": [
-              "src/styles.css"
+              "src/styles.scss"
             ],
             "scripts": []
           }

--- a/web-ng/src/app/components/inline-edit-title/inline-edit-title.component.scss
+++ b/web-ng/src/app/components/inline-edit-title/inline-edit-title.component.scss
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
- /* Relative top used to push title input field in line with flex row. */
+ 
+ @import '~src/custom-theme';
+ 
+/* Relative top used to push title input field in line with flex row. */
 .inline-edit {
   position: relative;
   top: 2px;
@@ -31,19 +33,19 @@ input {
   border: none;
   font-size: 14pt;
   margin: 10px 10px 5px 0;
-  border: 1px solid transparent;
-  color: #afa7a7
+  border: 2px solid transparent;
 }
 
+// !important used to override hover border color.
 .inline-edit:focus {
   padding: 2px 1px 2px 4px;
-  background: #fafafa;
   -webkit-box-shadow: inset 0px 1px 2px rgba(0, 0, 0, 0.1);
   -moz-box-shadow: inset 0px 1px 2px rgba(0, 0, 0, 0.1);
   box-shadow: inset 0px 1px 2px rgba(0, 0, 0, 0.1);
+  border: 2px solid mat-color($primary) !important;
 }
 
 .inline-edit:hover {
   padding: 2px 1px 2px 4px;
-  border: 1px solid #e0e0e0;
+  border: 2px solid mat-color($background, hover);
 }

--- a/web-ng/src/app/components/inline-edit-title/inline-edit-title.component.ts
+++ b/web-ng/src/app/components/inline-edit-title/inline-edit-title.component.ts
@@ -25,7 +25,7 @@ import { Subscription } from 'rxjs';
 @Component({
   selector: 'app-inline-edit-title',
   templateUrl: './inline-edit-title.component.html',
-  styleUrls: ['./inline-edit-title.component.css'],
+  styleUrls: ['./inline-edit-title.component.scss'],
 })
 export class InlineEditTitleComponent implements OnDestroy {
   readonly activeProject$: Observable<Project>;

--- a/web-ng/src/app/components/project-header/project-header.component.css
+++ b/web-ng/src/app/components/project-header/project-header.component.css
@@ -26,6 +26,7 @@
 .logo {
   width: 48px;
   height: 48px;
+  margin-left: 4px;
 }
 
 .app-title {

--- a/web-ng/src/app/components/project-header/project-header.component.scss
+++ b/web-ng/src/app/components/project-header/project-header.component.scss
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+ @import '~src/custom-theme';
+
 .header {
   padding: 16px;
   white-space: nowrap;
@@ -33,12 +35,12 @@
   margin-left: 12px;
   font-family: 'Open Sans', 'Helvetica neue', sans-serif;
   font-size: 14pt;
-  color: #7a7d81;
+  color: mat-color($foreground, secondary-text);
 }
 
 .header-divider {
   display: inline-block;
-  border-left: 1px solid #ddd;
+  border-left: 1px solid mat-color($foreground, divider);
   width: 1px;
   height: 30px;
   margin-left: 14px;

--- a/web-ng/src/app/components/project-header/project-header.component.ts
+++ b/web-ng/src/app/components/project-header/project-header.component.ts
@@ -22,7 +22,7 @@ import { MatDialog } from '@angular/material/dialog';
 @Component({
   selector: 'app-project-header',
   templateUrl: './project-header.component.html',
-  styleUrls: ['./project-header.component.css'],
+  styleUrls: ['./project-header.component.scss'],
 })
 export class ProjectHeaderComponent implements OnInit {
   constructor(public auth: AuthService, private dialog: MatDialog) {}

--- a/web-ng/src/custom-theme.scss
+++ b/web-ng/src/custom-theme.scss
@@ -27,12 +27,16 @@
 // Available color palettes: https://material.io/design/color/
 // TODO: Use custom color theme slightly with more saturated colors used in
 // Ground Android app.
-$web-ng-primary: mat-palette($mat-green, 700, 600, 800);
-$web-ng-accent: mat-palette($mat-amber, 700, 600, 800);
-$web-ng-warn: mat-palette($mat-pink, 600, 500, 700);
+$primary: mat-palette($mat-green, 700, 600, 800);
+$accent: mat-palette($mat-amber, 700, 600, 800);
+$warn: mat-palette($mat-pink, 600, 500, 700);
 
 // Create the theme object (a Sass map containing all of the palettes).
-$web-ng-theme: mat-light-theme($web-ng-primary, $web-ng-accent, $web-ng-warn);
+$theme: mat-light-theme($primary, $accent, $warn);
+
+// Get generated palletes from theme.
+$foreground: map-get($theme, foreground);
+$background: map-get($theme, background);
 
 // Include theme styles for core and each component used in the app.
-@include angular-material-theme($web-ng-theme);
+@include angular-material-theme($theme);

--- a/web-ng/src/custom-theme.scss
+++ b/web-ng/src/custom-theme.scss
@@ -34,7 +34,8 @@ $warn: mat-palette($mat-pink, 600, 500, 700);
 // Create the theme object (a Sass map containing all of the palettes).
 $theme: mat-light-theme($primary, $accent, $warn);
 
-// Get generated palletes from theme.
+// Get generated palletes from theme. Sub-palettes listed in:
+// https://github.com/angular/components/blob/16f5f793dea3d83a6f08de14e3787ce97d82ff15/src/material/core/theming/_palette.scss#L674
 $foreground: map-get($theme, foreground);
 $background: map-get($theme, background);
 

--- a/web-ng/src/custom-theme.scss
+++ b/web-ng/src/custom-theme.scss
@@ -34,7 +34,7 @@ $warn: mat-palette($mat-pink, 600, 500, 700);
 // Create the theme object (a Sass map containing all of the palettes).
 $theme: mat-light-theme($primary, $accent, $warn);
 
-// Get generated palletes from theme. Sub-palettes listed in:
+// Get generated palettes from theme. Sub-palettes listed in:
 // https://github.com/angular/components/blob/16f5f793dea3d83a6f08de14e3787ce97d82ff15/src/material/core/theming/_palette.scss#L674
 $foreground: map-get($theme, foreground);
 $background: map-get($theme, background);

--- a/web-ng/src/styles.scss
+++ b/web-ng/src/styles.scss
@@ -26,14 +26,12 @@ body {
 body {
   margin: 0;
   padding: 0;
-  font-family: Roboto, 'Helvetica Neue', sans-serif;
-  color: mat-color($foreground);
+  font-family: 'Roboto', 'Helvetica Neue', sans-serif;
 }
 
 button label {
   font-family: 'Open Sans', 'Helvetica Neue', sans-serif;
   font-weight: bold;
-  color: mat-color($foreground);
 }
 
 /* Space between button icon and label. */

--- a/web-ng/src/styles.scss
+++ b/web-ng/src/styles.scss
@@ -16,6 +16,8 @@
 
 /* You can add global styles to this file, and also import other style files */
 
+@import '~src/custom-theme';
+
 html,
 body {
   height: 100%;
@@ -25,12 +27,13 @@ body {
   margin: 0;
   padding: 0;
   font-family: Roboto, 'Helvetica Neue', sans-serif;
-  color: #212121;
+  color: mat-color($foreground);
 }
 
 button label {
   font-family: 'Open Sans', 'Helvetica Neue', sans-serif;
   font-weight: bold;
+  color: mat-color($foreground);
 }
 
 /* Space between button icon and label. */


### PR DESCRIPTION
There are a few more instances of hard-coded color codes left. This is intended as an example of how we can use the custom theme throughout out styles. @DaoyuT @gyarill FYI.