### PR TITLE
[Project] Reload project each time active user changes

### DIFF
--- a/web-ng/src/app/components/inline-edit-title/inline-edit-title.component.spec.ts
+++ b/web-ng/src/app/components/inline-edit-title/inline-edit-title.component.spec.ts
@@ -21,14 +21,26 @@ import { AngularFireModule } from '@angular/fire';
 import { AngularFireAuthModule } from '@angular/fire/auth';
 import { AngularFirestoreModule } from '@angular/fire/firestore';
 import { environment } from '../../../environments/environment';
+import { AuthService } from '../../services/auth/auth.service';
+import { User } from '../../shared/models/user.model';
+import { Subject } from 'rxjs';
 
 describe('InlineEditTitleComponent', () => {
   let component: InlineEditTitleComponent;
   let fixture: ComponentFixture<InlineEditTitleComponent>;
+  const user$ = new Subject<User | null>();
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [InlineEditTitleComponent],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: {
+            user$,
+          },
+        },
+      ],
       imports: [
         AutoSizeInputModule,
         AngularFireModule.initializeApp(environment.firebaseConfig),

--- a/web-ng/src/app/components/project-header/project-header.component.spec.ts
+++ b/web-ng/src/app/components/project-header/project-header.component.spec.ts
@@ -26,10 +26,15 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatDialogModule } from '@angular/material/dialog';
 import { UserProfilePopupComponent } from '../user-profile-popup/user-profile-popup.component';
+import { Subject } from 'rxjs';
+import { User } from '../../shared/models/user.model';
+
 describe('ProjectHeaderComponent', () => {
   let component: ProjectHeaderComponent;
   let fixture: ComponentFixture<ProjectHeaderComponent>;
   const dialogRef: Partial<MatDialogRef<UserProfilePopupComponent>> = {};
+  const user$ = new Subject<User | null>();
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
@@ -42,7 +47,12 @@ describe('ProjectHeaderComponent', () => {
       ],
       declarations: [ProjectHeaderComponent],
       providers: [
-        { provide: AuthService, useValue: {} },
+        {
+          provide: AuthService,
+          useValue: {
+            user$,
+          },
+        },
         { provide: MAT_DIALOG_DATA, useValue: {} },
         { provide: MatDialogRef, useValue: dialogRef },
       ],

--- a/web-ng/src/app/services/feature/feature.service.spec.ts
+++ b/web-ng/src/app/services/feature/feature.service.spec.ts
@@ -17,14 +17,23 @@
 import { TestBed } from '@angular/core/testing';
 import { FeatureService } from './feature.service';
 import { DataStoreService } from '../data-store/data-store.service';
+import { ProjectService } from '../project/project.service';
+import { Subject } from 'rxjs';
+import { Project } from '../../shared/models/project.model';
 
 describe('FeatureService', () => {
-  const dataStoreServiceStub: Partial<DataStoreService> = {};
+  const activeProject$ = new Subject<Project | null>();
 
   beforeEach(() =>
     TestBed.configureTestingModule({
       providers: [
-        { provide: DataStoreService, useValue: dataStoreServiceStub },
+        { provide: DataStoreService, useValue: {} },
+        {
+          provide: ProjectService,
+          useValue: {
+            getActiveProject$: () => activeProject$,
+          },
+        },
       ],
     })
   );

--- a/web-ng/src/app/services/feature/feature.service.ts
+++ b/web-ng/src/app/services/feature/feature.service.ts
@@ -32,7 +32,7 @@ export class FeatureService {
 
   constructor(
     private dataStore: DataStoreService,
-    private projectService: ProjectService
+    projectService: ProjectService
   ) {
     this.features$ = projectService
       .getActiveProject$()

--- a/web-ng/src/app/services/observation/observation.service.spec.ts
+++ b/web-ng/src/app/services/observation/observation.service.spec.ts
@@ -17,14 +17,16 @@
 import { TestBed } from '@angular/core/testing';
 import { ObservationService } from './observation.service';
 import { DataStoreService } from '../data-store/data-store.service';
+import { ProjectService } from '../project/project.service';
+import { FeatureService } from '../feature/feature.service';
 
 describe('ObservationService', () => {
-  const dataStoreServiceStub: Partial<DataStoreService> = {};
-
   beforeEach(() =>
     TestBed.configureTestingModule({
       providers: [
-        { provide: DataStoreService, useValue: dataStoreServiceStub },
+        { provide: DataStoreService, useValue: {} },
+        { provide: ProjectService, useValue: {} },
+        { provide: FeatureService, useValue: {} },
       ],
     })
   );

--- a/web-ng/src/app/services/observation/observation.service.ts
+++ b/web-ng/src/app/services/observation/observation.service.ts
@@ -34,8 +34,8 @@ export class ObservationService {
 
   constructor(
     private dataStore: DataStoreService,
-    private projectService: ProjectService,
-    private featureService: FeatureService
+    projectService: ProjectService,
+    featureService: FeatureService
   ) {
     this.selectedObservation$ = this.selectedObservationId$.pipe(
       switchMap(observationId =>

--- a/web-ng/src/app/services/project/project.service.spec.ts
+++ b/web-ng/src/app/services/project/project.service.spec.ts
@@ -18,14 +18,23 @@ import { TestBed } from '@angular/core/testing';
 
 import { ProjectService } from './project.service';
 import { DataStoreService } from '../data-store/data-store.service';
+import { AuthService } from '../auth/auth.service';
+import { Subject } from 'rxjs';
+import { User } from '../../shared/models/user.model';
 
 describe('ProjectService', () => {
   const dataStoreServiceStub: Partial<DataStoreService> = {};
-
+  const user$ = new Subject<User | null>();
   beforeEach(() =>
     TestBed.configureTestingModule({
       providers: [
         { provide: DataStoreService, useValue: dataStoreServiceStub },
+        {
+          provide: AuthService,
+          useValue: {
+            user$,
+          },
+        },
       ],
     })
   );


### PR DESCRIPTION
This fixes #295, a race condition where the project often wouldn't load since the user auth was not available yet. See also #296 TBD. Reloading the project causes all downstream details to reload as well (features, observation, etc.)