### PR TITLE
Fix template build errors and enable AOT compiler for all builds

### DIFF
--- a/web-ng/angular.json
+++ b/web-ng/angular.json
@@ -18,15 +18,9 @@
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
-            "aot": false,
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/custom-theme.scss",
-              "src/styles.scss"
-            ],
+            "aot": true,
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/custom-theme.scss", "src/styles.scss"],
             "scripts": []
           },
           "configurations": {
@@ -84,18 +78,15 @@
             "main": "src/test.ts",
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.spec.json",
-            "fileReplacements": [{
-              "replace": "src/environments/environment.ts",
-              "with": "src/environments/environment.test.ts"
-            }],
+            "fileReplacements": [
+              {
+                "replace": "src/environments/environment.ts",
+                "with": "src/environments/environment.test.ts"
+              }
+            ],
             "karmaConfig": "karma.conf.js",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.scss"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.scss"],
             "scripts": []
           }
         },
@@ -107,9 +98,7 @@
               "tsconfig.spec.json",
               "e2e/tsconfig.json"
             ],
-            "exclude": [
-              "**/node_modules/**"
-            ]
+            "exclude": ["**/node_modules/**"]
           }
         },
         "e2e": {

--- a/web-ng/src/app/components/form-field-editor/form-field-editor.component.ts
+++ b/web-ng/src/app/components/form-field-editor/form-field-editor.component.ts
@@ -233,6 +233,6 @@ export class FormFieldEditorComponent implements OnInit, OnChanges {
   }
 
   get labelControl() {
-    return this.formFieldGroup.get('label');
+    return this.formFieldGroup.get('label')!;
   }
 }

--- a/web-ng/src/app/components/layer-dialog/layer-dialog.component.html
+++ b/web-ng/src/app/components/layer-dialog/layer-dialog.component.html
@@ -22,9 +22,12 @@
 ></inline-editor>
 <div class="default-style">
   <div class="default-style-tag">Default style</div>
-  <app-edit-style-button [markerColor]="layer.color" (markerColorChange)="onMarkerColorChange($event)"></app-edit-style-button>
+  <app-edit-style-button
+    [markerColor]="layer!.color || '#000'"
+    (markerColorChange)="onMarkerColorChange($event)"
+  ></app-edit-style-button>
 </div>
-<form (ngSubmit)="onSave($event)">
+<form (ngSubmit)="onSave()">
   <mat-dialog-content>
     <div cdkDropList (cdkDropListDropped)="drop($event)">
       <div
@@ -44,7 +47,12 @@
         </app-form-field-editor>
       </div>
     </div>
-    <button mat-button class="add-question" type="button" (click)="addQuestion()">
+    <button
+      mat-button
+      class="add-question"
+      type="button"
+      (click)="addQuestion()"
+    >
       <span class="plus-icon"></span>
       <span class="link-add-question">Add question</span>
     </button>

--- a/web-ng/src/app/components/share-dialog/share-dialog.component.html
+++ b/web-ng/src/app/components/share-dialog/share-dialog.component.html
@@ -47,7 +47,7 @@
     <div class="list-heading">Collaborators</div>
   </div>
 </div>
-<div mat-dialog-content *ngIf="acl.length > 0">
+<div mat-dialog-content *ngIf="acl?.length > 0">
   <table mat-table role="list" fxFill>
     <!-- TODO: Format list, role names, allow edit role, delete. -->
     <tr

--- a/web-ng/src/app/components/user-profile-popup/user-profile-popup.component.html
+++ b/web-ng/src/app/components/user-profile-popup/user-profile-popup.component.html
@@ -14,7 +14,7 @@
   limitations under the License.
 -->
 <mat-dialog-content>
-  <div *ngIf="auth.user$ | async as user; else login" class="rhs-widgets">
+  <div *ngIf="auth.user$ | async as user" class="rhs-widgets">
     <img
       src="{{ user.photoURL }}=s64"
       alt="{{ user.displayName }}"
@@ -27,7 +27,8 @@
         class="btn-signout"
         mat-flat-button
         color="primary"
-        (click)="onSignOut($event)">
+        (click)="onSignOut($event)"
+      >
         Sign out
       </button>
     </div>

--- a/web-ng/tsconfig.app.json
+++ b/web-ng/tsconfig.app.json
@@ -1,18 +1,10 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./out-tsc/app",
     "types": ["googlemaps"]
   },
-  "files": [
-    "src/main.ts",
-    "src/polyfills.ts"
-  ],
-  "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "src/test.ts",
-    "src/**/*.spec.ts"
-  ]
+  "files": ["src/main.ts", "src/polyfills.ts"],
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/test.ts", "src/**/*.spec.ts"]
 }

--- a/web-ng/tsconfig.base.json
+++ b/web-ng/tsconfig.base.json
@@ -3,15 +3,9 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "build",
-    "lib": [
-      "es2018",
-      "dom"
-    ],
+    "lib": ["es2018", "dom"],
     "experimentalDecorators": true,
     "resolveJsonModule": true
   },
-  "include": [
-    "src/**/*.ts",
-    "test/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "test/**/*.ts"]
 }

--- a/web-ng/tsconfig.spec.json
+++ b/web-ng/tsconfig.spec.json
@@ -1,18 +1,9 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
-    "types": [
-      "jasmine",
-      "node"
-    ]
+    "types": ["jasmine", "node"]
   },
-  "files": [
-    "src/test.ts",
-    "src/polyfills.ts"
-  ],
-  "include": [
-    "src/**/*.spec.ts",
-    "src/**/*.d.ts"
-  ]
+  "files": ["src/test.ts", "src/polyfills.ts"],
+  "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
 }


### PR DESCRIPTION
Multiple errors were caught when running `ng build --prod`, which used the AOT compiler instead of JIT. This led to type checking being done on templates only when building for production. Switching to AOT for all builds will give us more consistent results and help us catch errors during development time.