### PR TITLE
Refactor dynamic stylesheets to reduce size of SCSS below default budget limit

### DIFF
--- a/web-ng/angular.json
+++ b/web-ng/angular.json
@@ -47,7 +47,7 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "2mb",
+                  "maximumWarning": "3mb",
                   "maximumError": "5mb"
                 },
                 {

--- a/web-ng/angular.json
+++ b/web-ng/angular.json
@@ -20,7 +20,11 @@
             "tsConfig": "tsconfig.app.json",
             "aot": true,
             "assets": ["src/favicon.ico", "src/assets"],
-            "styles": ["src/custom-theme.scss", "src/styles.scss"],
+            "styles": [
+              "src/_variables.scss",
+              "src/custom-theme.scss",
+              "src/styles.scss"
+            ],
             "scripts": []
           },
           "configurations": {
@@ -86,7 +90,11 @@
             ],
             "karmaConfig": "karma.conf.js",
             "assets": ["src/favicon.ico", "src/assets"],
-            "styles": ["src/styles.scss"],
+            "styles": [
+              "src/_variables.scss",
+              "src/custom-theme.scss",
+              "src/styles.scss"
+            ],
             "scripts": []
           }
         },

--- a/web-ng/src/_variables.scss
+++ b/web-ng/src/_variables.scss
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Custom Theming for Angular Material
+// For more information: https://material.angular.io/guide/theming
+@import '~@angular/material/theming';
+
+// Define Material palettes, including default, lighter, and darker hue.
+// Available color palettes: https://material.io/design/color/
+// TODO: Use custom color theme slightly with more saturated colors used in
+// Ground Android app.
+$primary: mat-palette($mat-green, 700, 600, 800);
+$accent: mat-palette($mat-amber, 700, 600, 800);
+$warn: mat-palette($mat-pink, 600, 500, 700);
+
+// Create the theme object (a Sass map containing all of the palettes).
+$theme: mat-light-theme($primary, $accent, $warn);
+
+// Get generated palettes from theme. Sub-palettes listed in:
+// https://github.com/angular/components/blob/16f5f793dea3d83a6f08de14e3787ce97d82ff15/src/material/core/theming/_palette.scss#L674
+$foreground: map-get($theme, foreground);
+$background: map-get($theme, background);

--- a/web-ng/src/app/components/form-field-editor/form-field-editor.component.html
+++ b/web-ng/src/app/components/form-field-editor/form-field-editor.component.html
@@ -65,7 +65,13 @@
         (delete)="onOptionDelete(i)"
       ></app-option-editor>
     </div>
-    <button mat-button type="button" (click)="onAddOption()" class="add-option">
+    <button
+      mat-button
+      type="button"
+      (click)="onAddOption()"
+      color="primary"
+      class="add-option"
+    >
       Add option
     </button>
   </div>

--- a/web-ng/src/app/components/form-field-editor/form-field-editor.component.scss
+++ b/web-ng/src/app/components/form-field-editor/form-field-editor.component.scss
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@import '~src/custom-theme';
-
 .field-type {
   margin-left: 30px;
   font-size: 12px;
@@ -63,7 +61,6 @@
 
 .add-option {
   margin-left: 30px;
-  color: mat-color($mat-green, 700);
 }
 
 .field-type-select {

--- a/web-ng/src/app/components/inline-edit-title/inline-edit-title.component.scss
+++ b/web-ng/src/app/components/inline-edit-title/inline-edit-title.component.scss
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@import '~src/custom-theme';
-
 :host {
   display: inline;
 }

--- a/web-ng/src/app/components/inline-editor/inline-editor.component.scss
+++ b/web-ng/src/app/components/inline-editor/inline-editor.component.scss
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@import '~src/custom-theme';
-
 :host {
   display: block;
   font-size: 1.5em;

--- a/web-ng/src/app/components/layer-list/layer-list.component.scss
+++ b/web-ng/src/app/components/layer-list/layer-list.component.scss
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
- @import '~src/custom-theme';
-
 .layer-list-title {
   padding: 20px;
 }

--- a/web-ng/src/app/components/option-editor/option-editor.component.scss
+++ b/web-ng/src/app/components/option-editor/option-editor.component.scss
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@import '~src/custom-theme';
+@import '~src/_variables';
 
 :host {
   display: flex;

--- a/web-ng/src/app/components/project-header/project-header.component.scss
+++ b/web-ng/src/app/components/project-header/project-header.component.scss
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 
- @import '~src/custom-theme';
+@import '~src/_variables';
 
 .header {
   padding: 16px;
   white-space: nowrap;
 }
 
-.header div, img, .header span, mat-icon {
+.header div,
+img,
+.header span,
+mat-icon {
   vertical-align: middle;
 }
 

--- a/web-ng/src/app/components/share-dialog/share-dialog.component.scss
+++ b/web-ng/src/app/components/share-dialog/share-dialog.component.scss
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@import '~src/custom-theme';
+@import '~src/_variables';
 
 .list-heading {
   font-size: medium;
@@ -44,6 +44,7 @@
 .remove-option {
   border-top: 1px solid mat-color($background, disabled-list-option);
 }
+
 .pending-changes {
   font-style: italic;
   color: mat-color($foreground, secondary-text);

--- a/web-ng/src/custom-theme.scss
+++ b/web-ng/src/custom-theme.scss
@@ -14,30 +14,7 @@
  * limitations under the License.
  */
 
-// Custom Theming for Angular Material
-// For more information: https://material.angular.io/guide/theming
-@import '~@angular/material/theming';
-
-// Include the common styles for Angular Material. This allows us to only
-// have to load a single css file for Angular Material in your app.
-// This mixin but be included exactly once!
-@include mat-core();
-
-// Define Material palettes, including default, lighter, and darker hue.
-// Available color palettes: https://material.io/design/color/
-// TODO: Use custom color theme slightly with more saturated colors used in
-// Ground Android app.
-$primary: mat-palette($mat-green, 700, 600, 800);
-$accent: mat-palette($mat-amber, 700, 600, 800);
-$warn: mat-palette($mat-pink, 600, 500, 700);
-
-// Create the theme object (a Sass map containing all of the palettes).
-$theme: mat-light-theme($primary, $accent, $warn);
-
-// Get generated palettes from theme. Sub-palettes listed in:
-// https://github.com/angular/components/blob/16f5f793dea3d83a6f08de14e3787ce97d82ff15/src/material/core/theming/_palette.scss#L674
-$foreground: map-get($theme, foreground);
-$background: map-get($theme, background);
+@import '~src/_variables';
 
 // Include theme styles for core and each component used in the app.
 @include angular-material-theme($theme);

--- a/web-ng/src/styles.scss
+++ b/web-ng/src/styles.scss
@@ -16,7 +16,7 @@
 
 /* You can add global styles to this file, and also import other style files */
 
-@import '~src/custom-theme';
+@import '~src/_variables';
 
 html,
 body {


### PR DESCRIPTION
- [x] Refactor scss color vars in separate include
- [x] Use Material component color attribute instead of custom CSS