### PR TITLE
[Layer list] Simplify styling and tweak layout

### DIFF
--- a/web-ng/src/app/components/layer-list-item/layer-list-item.component.css
+++ b/web-ng/src/app/components/layer-list-item/layer-list-item.component.css
@@ -13,15 +13,3 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
-img {
-    min-width: 24px;
-}
-
-.layer-list-item {
-    padding: 5px;
-}
-
-.layer-list-spacing {
-    padding-left: 10px;
-}

--- a/web-ng/src/app/components/layer-list-item/layer-list-item.component.css
+++ b/web-ng/src/app/components/layer-list-item/layer-list-item.component.css
@@ -13,3 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/*
+  Workaround to eliminate double-padding between right-hand side overflow
+  menu control and list item.
+*/
+:host ::ng-deep .mat-list-item-content {
+  padding-right: 8px !important;
+}

--- a/web-ng/src/app/components/layer-list-item/layer-list-item.component.html
+++ b/web-ng/src/app/components/layer-list-item/layer-list-item.component.html
@@ -14,9 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<mat-list-item class="layer-list-item">
-  <img [src]="layerPinUrl" />
-  <div class="layer-list-spacing">
+<mat-list-item>
+  <img matListAvatar [src]="layerPinUrl" />
+  <h3 matLine>
     {{ layer?.name?.get(lang) }}
-  </div>
+  </h3>
+  <button mat-icon-button>
+    <mat-icon>more_vert</mat-icon>
+  </button>
 </mat-list-item>

--- a/web-ng/src/app/components/layer-list-item/layer-list-item.module.ts
+++ b/web-ng/src/app/components/layer-list-item/layer-list-item.module.ts
@@ -1,3 +1,6 @@
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
 /**
  * Copyright 2020 Google LLC
  *
@@ -20,7 +23,13 @@ import { LayerListItemComponent } from './layer-list-item.component';
 import { MatListModule } from '@angular/material/list';
 
 @NgModule({
-  imports: [BrowserModule, MatListModule],
+  imports: [
+    BrowserModule,
+    FlexLayoutModule,
+    MatListModule,
+    MatButtonModule,
+    MatIconModule,
+  ],
   exports: [LayerListItemComponent],
   declarations: [LayerListItemComponent],
 })

--- a/web-ng/src/app/components/layer-list/layer-list.component.html
+++ b/web-ng/src/app/components/layer-list/layer-list.component.html
@@ -18,7 +18,6 @@ limitations under the License.
   *ngIf="layers$ | async as layers"
   role="list"
   fxLayoutRow
-  class="list-item"
 >
   <h3 matSubheader>Layers</h3>
   <mat-divider></mat-divider>

--- a/web-ng/src/app/components/layer-list/layer-list.component.html
+++ b/web-ng/src/app/components/layer-list/layer-list.component.html
@@ -21,16 +21,16 @@ limitations under the License.
     *ngFor="let entry of layers"
     [layer]="entry"
   ></ground-layer-list-item>
+  <div matLine class="add-layer">
+    <button
+      fxFill
+      mat-stroked-button
+      color="primary"
+      class="add-layer-btn"
+      (click)="onAddLayer()"
+    >
+      <mat-icon class="add-layer-icon">add</mat-icon>
+      Add layer
+    </button>
+  </div>
 </mat-list>
-<div fxFill class="add-layer">
-  <button
-    fxFill
-    mat-stroked-button
-    color="primary"
-    class="add-layer-btn"
-    (click)="onAddLayer()"
-  >
-    <mat-icon class="add-layer-icon">add</mat-icon>
-    Add layer
-  </button>
-</div>

--- a/web-ng/src/app/components/layer-list/layer-list.component.html
+++ b/web-ng/src/app/components/layer-list/layer-list.component.html
@@ -14,7 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<mat-list *ngIf="layers$ | async as layers" role="list" fxLayoutRow>
+<mat-list
+  *ngIf="layers$ | async as layers"
+  role="list"
+  fxLayoutRow
+  class="list-item"
+>
   <h3 matSubheader>Layers</h3>
   <mat-divider></mat-divider>
   <ground-layer-list-item

--- a/web-ng/src/app/components/layer-list/layer-list.component.html
+++ b/web-ng/src/app/components/layer-list/layer-list.component.html
@@ -14,34 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<mat-list *ngIf="layers$ | async as layers">
-  <div class="layer-list-title">
-    Layers
-  </div>
+<mat-list *ngIf="layers$ | async as layers" role="list" fxLayoutRow>
+  <h3 matSubheader>Layers</h3>
   <mat-divider></mat-divider>
-  <div
+  <ground-layer-list-item
     *ngFor="let entry of layers"
-    fxLayout="row"
-    fxLayoutAlign="center center"
-  >
-    <ground-layer-list-item
-      [layer]="entry"
-      fxFlex="fill"
-    ></ground-layer-list-item>
-    <button mat-icon-button>
-      <mat-icon>more_vert</mat-icon>
-    </button>
-  </div>
-  <div fxLayout="row" class="add-layer">
-    <button
-      fxFlex="fill"
-      mat-stroked-button
-      color="primary"
-      class="add-layer-btn"
-      (click)="onAddLayer()"
-    >
-      <mat-icon class="add-layer-icon">add</mat-icon>
-      Add layer
-    </button>
-  </div>
+    [layer]="entry"
+  ></ground-layer-list-item>
 </mat-list>
+<div fxFill class="add-layer">
+  <button
+    fxFill
+    mat-stroked-button
+    color="primary"
+    class="add-layer-btn"
+    (click)="onAddLayer()"
+  >
+    <mat-icon class="add-layer-icon">add</mat-icon>
+    Add layer
+  </button>
+</div>


### PR DESCRIPTION
This fix uses default styles and padding defined by Angular Material and https://material.io/components/lists#specs. The "avatar" icons (left-side icons in list) are currently oversized, but will be replaced in #331, so leaving as is for now. @jacobmclaws @sergeydolgov1 FYI.

Before:
![image](https://user-images.githubusercontent.com/228050/89566088-8792fe80-d7ed-11ea-8206-0187f77f8e97.png)

After:
![image](https://user-images.githubusercontent.com/228050/89566163-a8f3ea80-d7ed-11ea-8441-a95b9c647003.png)

Closes #348.