### PR TITLE
Deselect marker and set all markers unclickable when entering edit mode.

### DIFF
--- a/web-ng/src/app/components/drawing-tools/drawing-tools.component.html
+++ b/web-ng/src/app/components/drawing-tools/drawing-tools.component.html
@@ -20,7 +20,7 @@ class="drawing-buttons"
   <mat-button-toggle value = "{{pointValue}}" (click)="onButtonClick()">
     add point
   </mat-button-toggle>
-  <mat-button-toggle value = "{{polygonValue}}" (click)="onButtonClick()">
+  <mat-button-toggle hidden value = "{{polygonValue}}" (click)="onButtonClick()">
     add polygon
   </mat-button-toggle>
 </mat-button-toggle-group>

--- a/web-ng/src/app/components/map/map.component.ts
+++ b/web-ng/src/app/components/map/map.component.ts
@@ -107,6 +107,17 @@ export class MapComponent implements AfterViewInit, OnDestroy {
   }
 
   onEditModeChange(editMode: EditMode) {
+    if (editMode !== EditMode.None) {
+      this.selectMarker(undefined);
+      this.navigationService.setFeatureId(null);
+      for (const marker of this.markers) {
+        marker.setClickable(false);
+      }
+    } else {
+      for (const marker of this.markers) {
+        marker.setClickable(true);
+      }
+    }
     this.mapOptions =
       editMode === EditMode.AddPoint
         ? this.crosshairCursorMapOptions


### PR DESCRIPTION
Fixes #482, fixes #468.

Behavior now:
Click a marker, it gets bigger, routed to that feature.
Click `add point`, the selected marker returns to normal size, routed to project url with no fragment parameter.
Click `add point` again, exits edit mode. All markers back to clickable.

There is only `add point` button on the map, no `add polygon`.