### PR TITLE
Add clickable UI component to profile icon

### DIFF
--- a/web-ng/src/app/components/project-header/project-header.component.html
+++ b/web-ng/src/app/components/project-header/project-header.component.html
@@ -35,12 +35,14 @@
       <button mat-icon-button aria-label="More project settings">
         <mat-icon>more_vert</mat-icon>
       </button>
-      <img
-        *ngIf="user.photoURL; else defaultPhoto"
-        src="{{ user.photoURL }}=s64"
-        class="user-thumb"
-        (click)="openProfileDialog($event)"
-      />
+      <button mat-icon-button>
+        <img
+          *ngIf="user.photoURL; else defaultPhoto"
+          src="{{ user.photoURL }}=s64"
+          class="user-thumb"
+          (click)="openProfileDialog($event)"
+        />
+      </button>
       <ng-template #defaultPhoto>
         <user-avatar
           (click)="openProfileDialog($event)"

--- a/web-ng/src/app/components/project-header/project-header.component.scss
+++ b/web-ng/src/app/components/project-header/project-header.component.scss
@@ -55,9 +55,9 @@ app-inline-edit-title {
 }
 
 .user-thumb {
-  width: 32px;
-  height: 32px;
-  border-radius: 32px;
+  max-width: 100%;
+  max-height: 100%;
+  border-radius: 50%;
   margin-right: 8px;
 }
 

--- a/web-ng/src/app/components/user-profile-popup/user-profile-popup.component.scss
+++ b/web-ng/src/app/components/user-profile-popup/user-profile-popup.component.scss
@@ -25,7 +25,7 @@
 .user-thumb {
   display: block;
   margin: 0px auto;
-  border-radius: 32px;
+  border-radius: 50%;
 }
 
 .user-email {


### PR DESCRIPTION
Hi @gino-m, this Pull request Closes #489.

**GIF:**
![Screen Recording 2020-11-11 at 1 57 27 AM](https://user-images.githubusercontent.com/45903885/98785033-9b886680-23c1-11eb-99f1-e4cc281db3dd.gif)



**Changes:**

- [x] Used `max-width` and `max-height` which would inherit `mat-icon-button`'s `40px x 40px` default size
- [x] Used `border-radius: 50%;`, fixes:

Before
<img width="200" alt="Screen Shot 2020-11-11 at 1 04 13 AM" src="https://user-images.githubusercontent.com/45903885/98784028-1486be80-23c0-11eb-86ed-7d607cdce069.png">

After
<img width="200" alt="Screen Shot 2020-11-11 at 1 04 52 AM" src="https://user-images.githubusercontent.com/45903885/98784070-2700f800-23c0-11eb-88c1-cdbe13cdbe9d.png">

