### PR TITLE
Clean up and fix unit test failures and warnings

### DIFF
--- a/web-ng/src/app/components/color-picker/color-picker.component.spec.ts
+++ b/web-ng/src/app/components/color-picker/color-picker.component.spec.ts
@@ -16,7 +16,6 @@
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ColorPickerComponent } from './color-picker.component';
-import { CommonModule } from '@angular/common';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
@@ -30,7 +29,7 @@ describe('ColorPickerComponent', () => {
     waitForAsync(() => {
       TestBed.configureTestingModule({
         declarations: [ColorPickerComponent],
-        imports: [CommonModule, MatDialogModule],
+        imports: [MatDialogModule],
         providers: [
           { provide: MAT_DIALOG_DATA, useValue: {} },
           { provide: MatDialogRef, useValue: dialogRef },

--- a/web-ng/src/app/components/color-picker/color-picker.component.spec.ts
+++ b/web-ng/src/app/components/color-picker/color-picker.component.spec.ts
@@ -18,11 +18,8 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ColorPickerComponent } from './color-picker.component';
 import { CommonModule } from '@angular/common';
 import { MatDialogModule } from '@angular/material/dialog';
-import { ColorCircleModule } from 'ngx-color/circle';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { ReactiveFormsModule } from '@angular/forms';
-import { MatIconModule } from '@angular/material/icon';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 describe('ColorPickerComponent', () => {
   let component: ColorPickerComponent;
@@ -33,18 +30,12 @@ describe('ColorPickerComponent', () => {
     waitForAsync(() => {
       TestBed.configureTestingModule({
         declarations: [ColorPickerComponent],
-        imports: [
-          CommonModule,
-          MatDialogModule,
-          MatFormFieldModule,
-          ColorCircleModule,
-          ReactiveFormsModule,
-          MatIconModule,
-        ],
+        imports: [CommonModule, MatDialogModule],
         providers: [
           { provide: MAT_DIALOG_DATA, useValue: {} },
           { provide: MatDialogRef, useValue: dialogRef },
         ],
+        schemas: [NO_ERRORS_SCHEMA],
       }).compileComponents();
     })
   );

--- a/web-ng/src/app/components/edit-style-button/edit-style-button.component.spec.ts
+++ b/web-ng/src/app/components/edit-style-button/edit-style-button.component.spec.ts
@@ -16,8 +16,8 @@
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { EditStyleButtonComponent } from './edit-style-button.component';
-import { MatIconModule } from '@angular/material/icon';
 import { MatDialogModule } from '@angular/material/dialog';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 describe('EditStyleButtonComponent', () => {
   let component: EditStyleButtonComponent;
@@ -27,7 +27,8 @@ describe('EditStyleButtonComponent', () => {
     waitForAsync(() => {
       TestBed.configureTestingModule({
         declarations: [EditStyleButtonComponent],
-        imports: [MatDialogModule, MatIconModule],
+        imports: [MatDialogModule],
+        schemas: [NO_ERRORS_SCHEMA],
       }).compileComponents();
     })
   );

--- a/web-ng/src/app/components/feature-panel/feature-panel.component.spec.ts
+++ b/web-ng/src/app/components/feature-panel/feature-panel.component.spec.ts
@@ -16,6 +16,7 @@
 
 import firebase from 'firebase/app';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { DataStoreService } from './../../services/data-store/data-store.service';
 import { FeaturePanelComponent } from './feature-panel.component';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { of } from 'rxjs';
@@ -29,7 +30,6 @@ import { ProjectService } from '../../services/project/project.service';
 import { FeatureService } from '../../services/feature/feature.service';
 import { ObservationService } from '../../services/observation/observation.service';
 import { Router } from '@angular/router';
-import { AngularFireModule, FIREBASE_OPTIONS } from '@angular/fire';
 
 const mockProject = new Project(
   'project001',
@@ -86,9 +86,8 @@ describe('FeaturePanelComponent', () => {
       const routerSpy = createRouterSpy();
       TestBed.configureTestingModule({
         declarations: [FeaturePanelComponent],
-        imports: [AngularFireModule],
         providers: [
-          { provide: FIREBASE_OPTIONS, useValue: {} },
+          { provide: DataStoreService, useValue: {} },
           { provide: FeatureService, useValue: featureService },
           { provide: ProjectService, useValue: projectService },
           { provide: ObservationService, useValue: observationService },

--- a/web-ng/src/app/components/form-field-editor/form-field-editor.component.spec.ts
+++ b/web-ng/src/app/components/form-field-editor/form-field-editor.component.spec.ts
@@ -15,7 +15,6 @@
  */
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-
 import { FormFieldEditorComponent } from './form-field-editor.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
@@ -23,14 +22,12 @@ import { LayerService } from './../../services/layer/layer.service';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { BehaviorSubject } from 'rxjs';
 import { MatDialogModule } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('FormFieldEditorComponent', () => {
   let component: FormFieldEditorComponent;
@@ -47,8 +44,10 @@ describe('FormFieldEditorComponent', () => {
           MatDialogModule,
           MatIconModule,
           MatSelectModule,
+          MatSlideToggleModule,
           MatFormFieldModule,
           MatInputModule,
+          NoopAnimationsModule,
         ],
         providers: [
           { provide: Router, useValue: {} },

--- a/web-ng/src/app/components/form-field-editor/form-field-editor.component.spec.ts
+++ b/web-ng/src/app/components/form-field-editor/form-field-editor.component.spec.ts
@@ -30,15 +30,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { BehaviorSubject } from 'rxjs';
 import { MatDialogModule } from '@angular/material/dialog';
 import { Router } from '@angular/router';
-
-const firestoreStub = {
-  collection: () => ({
-    doc: () => ({
-      valueChanges: () => new BehaviorSubject({}),
-      set: () => new Promise(resolve => resolve()),
-    }),
-  }),
-};
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 describe('FormFieldEditorComponent', () => {
   let component: FormFieldEditorComponent;
@@ -55,16 +47,14 @@ describe('FormFieldEditorComponent', () => {
           MatDialogModule,
           MatIconModule,
           MatSelectModule,
-          MatSlideToggleModule,
-          MatProgressSpinnerModule,
           MatFormFieldModule,
           MatInputModule,
-          BrowserAnimationsModule,
         ],
         providers: [
           { provide: Router, useValue: {} },
           { provide: LayerService, useValue: {} },
         ],
+        schemas: [NO_ERRORS_SCHEMA],
       }).compileComponents();
     })
   );

--- a/web-ng/src/app/components/form-field-editor/form-field-editor.component.spec.ts
+++ b/web-ng/src/app/components/form-field-editor/form-field-editor.component.spec.ts
@@ -19,8 +19,10 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormFieldEditorComponent } from './form-field-editor.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
+import { MatIconModule } from '@angular/material/icon';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -58,8 +60,10 @@ describe('FormFieldEditorComponent', () => {
           FormsModule,
           ReactiveFormsModule,
           BrowserModule,
+          MatIconModule,
           MatSelectModule,
           MatSlideToggleModule,
+          MatProgressSpinnerModule,
           MatFormFieldModule,
           MatInputModule,
           BrowserAnimationsModule,

--- a/web-ng/src/app/components/layer-dialog/layer-dialog.component.spec.ts
+++ b/web-ng/src/app/components/layer-dialog/layer-dialog.component.spec.ts
@@ -16,16 +16,14 @@
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { Component } from '@angular/core';
+import { DataStoreService } from './../../services/data-store/data-store.service';
+import { ProjectService } from './../../services/project/project.service';
 import { LayerDialogComponent } from './layer-dialog.component';
 import {
   MAT_DIALOG_DATA,
   MatDialogRef,
   MatDialogModule,
 } from '@angular/material/dialog';
-import { AngularFireModule, FIREBASE_OPTIONS } from '@angular/fire';
-import { AngularFireAuthModule } from '@angular/fire/auth';
-import { AngularFirestoreModule } from '@angular/fire/firestore';
-import { environment } from '../../../environments/environment';
 import { Router } from '@angular/router';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -56,9 +54,6 @@ describe('LayerDialogComponent', () => {
           MatDialogActions,
         ],
         imports: [
-          AngularFireModule,
-          AngularFireAuthModule,
-          AngularFirestoreModule,
           FormsModule,
           InlineEditorModule,
           ReactiveFormsModule,
@@ -70,7 +65,8 @@ describe('LayerDialogComponent', () => {
           MatIconModule,
         ],
         providers: [
-          { provide: FIREBASE_OPTIONS, useValue: environment.firebaseConfig },
+          { provide: ProjectService, useValue: {} },
+          { provide: DataStoreService, useValue: { generateId: () => '123' } },
           { provide: MAT_DIALOG_DATA, useValue: { createLayer: true } },
           { provide: MatDialogRef, useValue: dialogRef },
           { provide: Router, useValue: routerSpy },

--- a/web-ng/src/app/components/layer-dialog/layer-dialog.component.spec.ts
+++ b/web-ng/src/app/components/layer-dialog/layer-dialog.component.spec.ts
@@ -17,6 +17,7 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { Component } from '@angular/core';
 import { DataStoreService } from './../../services/data-store/data-store.service';
+import { EditStyleButtonModule } from './../edit-style-button/edit-style-button.module';
 import { ProjectService } from './../../services/project/project.service';
 import { LayerDialogComponent } from './layer-dialog.component';
 import {
@@ -54,6 +55,7 @@ describe('LayerDialogComponent', () => {
           MatDialogActions,
         ],
         imports: [
+          EditStyleButtonModule,
           FormsModule,
           InlineEditorModule,
           ReactiveFormsModule,

--- a/web-ng/src/app/components/layer-dialog/layer-dialog.component.spec.ts
+++ b/web-ng/src/app/components/layer-dialog/layer-dialog.component.spec.ts
@@ -18,6 +18,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { Component } from '@angular/core';
 import { DataStoreService } from './../../services/data-store/data-store.service';
 import { EditStyleButtonModule } from './../edit-style-button/edit-style-button.module';
+import { FormFieldEditorModule } from './../form-field-editor/form-field-editor.module';
 import { ProjectService } from './../../services/project/project.service';
 import { LayerDialogComponent } from './layer-dialog.component';
 import {
@@ -57,6 +58,7 @@ describe('LayerDialogComponent', () => {
         imports: [
           EditStyleButtonModule,
           FormsModule,
+          FormFieldEditorModule,
           InlineEditorModule,
           ReactiveFormsModule,
           BrowserAnimationsModule,

--- a/web-ng/src/app/components/layer-list-item/layer-list-item.component.spec.ts
+++ b/web-ng/src/app/components/layer-list-item/layer-list-item.component.spec.ts
@@ -16,6 +16,7 @@
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { LayerListItemComponent } from './layer-list-item.component';
+import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatListModule } from '@angular/material/list';
 import { NavigationService } from './../../services/router/router.service';
@@ -38,7 +39,7 @@ describe('LayerListItemComponent', () => {
 
       TestBed.configureTestingModule({
         declarations: [LayerListItemComponent],
-        imports: [MatListModule, MatMenuModule, MatDialogModule],
+        imports: [MatIconModule, MatListModule, MatMenuModule, MatDialogModule],
         providers: [
           { provide: NavigationService, useValue: navigationService },
           { provide: Router, useValue: {} },

--- a/web-ng/src/app/components/layer-list/layer-list.component.spec.ts
+++ b/web-ng/src/app/components/layer-list/layer-list.component.spec.ts
@@ -15,7 +15,6 @@
  */
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { DataStoreService } from './../../services/data-store/data-store.service';
 import { LayerListComponent } from './layer-list.component';
 import { ProjectService } from '../../services/project/project.service';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
@@ -24,7 +23,6 @@ import { of } from 'rxjs';
 import { Map } from 'immutable';
 import { StringMap } from '../../shared/models/string-map.model';
 import { Layer } from '../../shared/models/layer.model';
-import { LayerListItemModule } from '../layer-list-item/layer-list-item.module';
 import { MatListModule } from '@angular/material/list';
 import { Router } from '@angular/router';
 import { NavigationService } from '../../services/router/router.service';
@@ -66,10 +64,8 @@ describe('LayerListComponent', () => {
       const routerSpy = createRouterSpy();
       TestBed.configureTestingModule({
         declarations: [LayerListComponent],
-        imports: [LayerListItemModule, MatListModule],
+        imports: [MatListModule],
         providers: [
-          // Why is DataStoreService required if it's only used transitively?
-          { provide: DataStoreService, useValue: {} },
           { provide: ProjectService, useValue: projectService },
           {
             provide: Router,

--- a/web-ng/src/app/components/layer-list/layer-list.component.spec.ts
+++ b/web-ng/src/app/components/layer-list/layer-list.component.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-
+import { DataStoreService } from './../../services/data-store/data-store.service';
 import { LayerListComponent } from './layer-list.component';
 import { ProjectService } from '../../services/project/project.service';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
@@ -68,6 +68,8 @@ describe('LayerListComponent', () => {
         declarations: [LayerListComponent],
         imports: [LayerListItemModule, MatListModule],
         providers: [
+          // Why is DataStoreService required if it's only used transitively?
+          { provide: DataStoreService, useValue: {} },
           { provide: ProjectService, useValue: projectService },
           {
             provide: Router,

--- a/web-ng/src/app/components/main-page-container/main-page-container.component.spec.ts
+++ b/web-ng/src/app/components/main-page-container/main-page-container.component.spec.ts
@@ -19,10 +19,10 @@ import { ActivatedRoute } from '@angular/router';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MainPageContainerComponent } from './main-page-container.component';
 import { MainPageComponent } from './../main-page/main-page.component';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { NavigationService } from './../../services/router/router.service';
 import { NEVER } from 'rxjs';
 import { ProjectService } from './../../services/project/project.service';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 const navigationService = {
   init: () => {},
@@ -44,12 +44,12 @@ describe('MainPageContainerComponent', () => {
       route = new ActivatedRouteStub();
       TestBed.configureTestingModule({
         declarations: [MainPageContainerComponent, MainPageComponent],
-        imports: [MatProgressSpinnerModule],
         providers: [
           { provide: ActivatedRoute, useValue: route },
           { provide: NavigationService, useValue: navigationService },
           { provide: ProjectService, useValue: projectService },
         ],
+        schemas: [NO_ERRORS_SCHEMA],
       }).compileComponents();
 
       fixture = TestBed.createComponent(MainPageContainerComponent);

--- a/web-ng/src/app/components/main-page-container/main-page-container.component.spec.ts
+++ b/web-ng/src/app/components/main-page-container/main-page-container.component.spec.ts
@@ -19,6 +19,7 @@ import { ActivatedRoute } from '@angular/router';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MainPageContainerComponent } from './main-page-container.component';
 import { MainPageComponent } from './../main-page/main-page.component';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { NavigationService } from './../../services/router/router.service';
 import { NEVER } from 'rxjs';
 import { ProjectService } from './../../services/project/project.service';
@@ -43,6 +44,7 @@ describe('MainPageContainerComponent', () => {
       route = new ActivatedRouteStub();
       TestBed.configureTestingModule({
         declarations: [MainPageContainerComponent, MainPageComponent],
+        imports: [MatProgressSpinnerModule],
         providers: [
           { provide: ActivatedRoute, useValue: route },
           { provide: NavigationService, useValue: navigationService },

--- a/web-ng/src/app/components/main-page/main-page.component.spec.ts
+++ b/web-ng/src/app/components/main-page/main-page.component.spec.ts
@@ -22,7 +22,6 @@ import { ActivatedRouteStub } from '../../../testing/activated-route-stub';
 import { ProjectService } from '../../services/project/project.service';
 import { MatDialog } from '@angular/material/dialog';
 import { FeatureService } from '../../services/feature/feature.service';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { ObservationService } from '../../services/observation/observation.service';
 import { NavigationService } from './../../services/router/router.service';
 import { NEVER } from 'rxjs';
@@ -66,7 +65,6 @@ describe('MainPageComponent', () => {
 
       TestBed.configureTestingModule({
         declarations: [MainPageComponent, MapComponent, MatSideNavComponent],
-        imports: [MatProgressSpinnerModule],
         providers: [
           { provide: ActivatedRoute, useValue: route },
           { provide: MatDialog, useValue: dialog },

--- a/web-ng/src/app/components/main-page/main-page.component.spec.ts
+++ b/web-ng/src/app/components/main-page/main-page.component.spec.ts
@@ -22,6 +22,7 @@ import { ActivatedRouteStub } from '../../../testing/activated-route-stub';
 import { ProjectService } from '../../services/project/project.service';
 import { MatDialog } from '@angular/material/dialog';
 import { FeatureService } from '../../services/feature/feature.service';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { ObservationService } from '../../services/observation/observation.service';
 import { NavigationService } from './../../services/router/router.service';
 import { NEVER } from 'rxjs';
@@ -65,6 +66,7 @@ describe('MainPageComponent', () => {
 
       TestBed.configureTestingModule({
         declarations: [MainPageComponent, MapComponent, MatSideNavComponent],
+        imports: [MatProgressSpinnerModule],
         providers: [
           { provide: ActivatedRoute, useValue: route },
           { provide: MatDialog, useValue: dialog },

--- a/web-ng/src/app/components/observation-form/observation-form.component.spec.ts
+++ b/web-ng/src/app/components/observation-form/observation-form.component.spec.ts
@@ -1,3 +1,4 @@
+import { DataStoreService } from './../../services/data-store/data-store.service';
 /**
  * Copyright 2020 Google LLC
  *
@@ -18,8 +19,6 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { ObservationFormComponent } from './observation-form.component';
 import { Feature, LocationFeature } from '../../shared/models/feature.model';
-import { AngularFireModule, FIREBASE_OPTIONS } from '@angular/fire';
-import { environment } from '../../../environments/environment';
 import { never, of, Subject } from 'rxjs';
 import { Project } from '../../shared/models/project.model';
 import { List, Map } from 'immutable';
@@ -175,7 +174,6 @@ describe('ObservationFormComponent', () => {
       TestBed.configureTestingModule({
         declarations: [ObservationFormComponent],
         imports: [
-          AngularFireModule,
           BrowserAnimationsModule,
           FormsModule,
           ReactiveFormsModule,
@@ -190,18 +188,13 @@ describe('ObservationFormComponent', () => {
           LayerListItemModule,
         ],
         providers: [
-          { provide: FIREBASE_OPTIONS, useValue: environment.firebaseConfig },
+          { provide: DataStoreService, useValue: {} },
           { provide: FeatureService, useValue: featureService },
           { provide: ProjectService, useValue: projectService },
           { provide: ObservationService, useValue: observationService },
           { provide: Router, useValue: routerSpy },
           { provide: NavigationService, useValue: navigationService },
-          {
-            provide: AuthService,
-            useValue: {
-              user$,
-            },
-          },
+          { provide: AuthService, useValue: { user$ } },
         ],
         schemas: [NO_ERRORS_SCHEMA],
       }).compileComponents();

--- a/web-ng/src/app/components/option-editor/option-editor.component.spec.ts
+++ b/web-ng/src/app/components/option-editor/option-editor.component.spec.ts
@@ -19,6 +19,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { OptionEditorComponent } from './option-editor.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { FlexLayoutModule } from '@angular/flex-layout';
@@ -37,6 +38,7 @@ describe('OptionEditorComponent', () => {
           CommonModule,
           BrowserAnimationsModule,
           FlexLayoutModule,
+          MatIconModule,
           MatFormFieldModule,
           FormsModule,
           ReactiveFormsModule,

--- a/web-ng/src/app/components/project-header/project-header.component.spec.ts
+++ b/web-ng/src/app/components/project-header/project-header.component.spec.ts
@@ -1,4 +1,3 @@
-import { ProjectService } from './../../services/project/project.service';
 /**
  * Copyright 2020 Google LLC
  *
@@ -17,7 +16,9 @@ import { ProjectService } from './../../services/project/project.service';
 
 import { AuthService } from './../../services/auth/auth.service';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { InlineEditorModule } from './../inline-editor/inline-editor.module';
 import { ProjectHeaderComponent } from './project-header.component';
+import { ProjectService } from './../../services/project/project.service';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatDialogModule } from '@angular/material/dialog';
@@ -35,7 +36,7 @@ describe('ProjectHeaderComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [MatIconModule, MatDialogModule],
+        imports: [InlineEditorModule, MatIconModule, MatDialogModule],
         declarations: [ProjectHeaderComponent],
         providers: [
           { provide: AuthService, useValue: { user$ } },

--- a/web-ng/src/app/components/project-header/project-header.component.spec.ts
+++ b/web-ng/src/app/components/project-header/project-header.component.spec.ts
@@ -1,3 +1,4 @@
+import { ProjectService } from './../../services/project/project.service';
 /**
  * Copyright 2020 Google LLC
  *
@@ -16,16 +17,12 @@
 
 import { AuthService } from './../../services/auth/auth.service';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { AngularFireModule, FIREBASE_OPTIONS } from '@angular/fire';
-import { AngularFireAuthModule } from '@angular/fire/auth';
-import { AngularFirestoreModule } from '@angular/fire/firestore';
 import { ProjectHeaderComponent } from './project-header.component';
-import { environment } from '../../../environments/environment';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatDialogModule } from '@angular/material/dialog';
 import { UserProfilePopupComponent } from '../user-profile-popup/user-profile-popup.component';
-import { Subject } from 'rxjs';
+import { NEVER, Subject } from 'rxjs';
 import { User } from '../../shared/models/user.model';
 import { Router } from '@angular/router';
 
@@ -38,24 +35,16 @@ describe('ProjectHeaderComponent', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [
-          AngularFireModule,
-          AngularFireAuthModule,
-          AngularFirestoreModule,
-          MatIconModule,
-          MatDialogModule,
-        ],
+        imports: [MatIconModule, MatDialogModule],
         declarations: [ProjectHeaderComponent],
         providers: [
-          { provide: FIREBASE_OPTIONS, useValue: environment.firebaseConfig },
-          {
-            provide: AuthService,
-            useValue: {
-              user$,
-            },
-          },
+          { provide: AuthService, useValue: { user$ } },
           { provide: MAT_DIALOG_DATA, useValue: {} },
           { provide: MatDialogRef, useValue: dialogRef },
+          {
+            provide: ProjectService,
+            useValue: { getActiveProject$: () => NEVER },
+          },
           { provide: Router, useValue: {} },
         ],
       }).compileComponents();

--- a/web-ng/src/app/components/share-dialog/share-dialog.component.spec.ts
+++ b/web-ng/src/app/components/share-dialog/share-dialog.component.spec.ts
@@ -15,15 +15,19 @@
  */
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-
 import { ShareDialogComponent } from './share-dialog.component';
-import { MatDialogRef } from '@angular/material/dialog';
+import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatListModule } from '@angular/material/list';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { FlexLayoutModule } from '@angular/flex-layout';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { ProjectService } from '../../services/project/project.service';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { of } from 'rxjs';
 import { Map } from 'immutable';
-import { MatOptionModule } from '@angular/material/core';
 
 describe('ShareDialogComponent', () => {
   let component: ShareDialogComponent;
@@ -33,7 +37,18 @@ describe('ShareDialogComponent', () => {
     waitForAsync(() => {
       TestBed.configureTestingModule({
         declarations: [ShareDialogComponent],
-        imports: [MatFormFieldModule, MatSelectModule, MatOptionModule],
+        imports: [
+          NoopAnimationsModule,
+          FlexLayoutModule,
+          MatButtonModule,
+          MatDialogModule,
+          MatFormFieldModule,
+          MatInputModule,
+          MatListModule,
+          MatSelectModule,
+          FormsModule,
+          ReactiveFormsModule,
+        ],
         providers: [
           { provide: MatDialogRef, useValue: {} },
           {

--- a/web-ng/src/app/components/share-dialog/share-dialog.component.spec.ts
+++ b/web-ng/src/app/components/share-dialog/share-dialog.component.spec.ts
@@ -18,9 +18,12 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { ShareDialogComponent } from './share-dialog.component';
 import { MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
 import { ProjectService } from '../../services/project/project.service';
 import { of } from 'rxjs';
 import { Map } from 'immutable';
+import { MatOptionModule } from '@angular/material/core';
 
 describe('ShareDialogComponent', () => {
   let component: ShareDialogComponent;
@@ -30,6 +33,7 @@ describe('ShareDialogComponent', () => {
     waitForAsync(() => {
       TestBed.configureTestingModule({
         declarations: [ShareDialogComponent],
+        imports: [MatFormFieldModule, MatSelectModule, MatOptionModule],
         providers: [
           { provide: MatDialogRef, useValue: {} },
           {

--- a/web-ng/src/app/components/share-dialog/share-dialog.module.ts
+++ b/web-ng/src/app/components/share-dialog/share-dialog.module.ts
@@ -17,6 +17,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatDialogModule } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
 import { ShareDialogComponent } from './share-dialog.component';
 import { MatButtonModule } from '@angular/material/button';
 import { MatInputModule } from '@angular/material/input';
@@ -24,6 +25,7 @@ import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { MatSelectModule } from '@angular/material/select';
 import { MatListModule } from '@angular/material/list';
 import { FlexLayoutModule } from '@angular/flex-layout';
+import { MatFormField } from '@angular/material/form-field';
 
 @NgModule({
   declarations: [ShareDialogComponent],
@@ -32,6 +34,7 @@ import { FlexLayoutModule } from '@angular/flex-layout';
     FlexLayoutModule,
     MatButtonModule,
     MatDialogModule,
+    MatFormFieldModule,
     MatInputModule,
     MatListModule,
     MatSelectModule,

--- a/web-ng/src/app/components/user-profile-popup/user-profile-popup.component.spec.ts
+++ b/web-ng/src/app/components/user-profile-popup/user-profile-popup.component.spec.ts
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
+import { AuthService } from './../../services/auth/auth.service';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { UserProfilePopupComponent } from './user-profile-popup.component';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatDialogModule } from '@angular/material/dialog';
-import { AngularFireModule, FIREBASE_OPTIONS } from '@angular/fire';
-import { AngularFireAuthModule } from '@angular/fire/auth';
-import { AngularFirestoreModule } from '@angular/fire/firestore';
-import { environment } from '../../../environments/environment';
 import { Router } from '@angular/router';
 
 describe('UserProfilePopupComponent', () => {
@@ -34,14 +31,9 @@ describe('UserProfilePopupComponent', () => {
       const routerSpy = createRouterSpy();
       TestBed.configureTestingModule({
         declarations: [UserProfilePopupComponent],
-        imports: [
-          MatDialogModule,
-          AngularFireModule,
-          AngularFireAuthModule,
-          AngularFirestoreModule,
-        ],
+        imports: [MatDialogModule],
         providers: [
-          { provide: FIREBASE_OPTIONS, useValue: environment.firebaseConfig },
+          { provide: AuthService, useValue: {} },
           { provide: MAT_DIALOG_DATA, useValue: {} },
           { provide: MatDialogRef, useValue: dialogRef },
           { provide: Router, useValue: routerSpy },

--- a/web-ng/src/app/services/auth/auth.service.spec.ts
+++ b/web-ng/src/app/services/auth/auth.service.spec.ts
@@ -18,23 +18,16 @@ import { TestBed } from '@angular/core/testing';
 import { NEVER } from 'rxjs';
 import { Router } from '@angular/router';
 import { AngularFireAuth } from '@angular/fire/auth';
+import { AngularFirestore } from '@angular/fire/firestore';
 import { DataStoreService } from '../data-store/data-store.service';
 import { AuthService } from './auth.service';
-import { AngularFireModule, FIREBASE_OPTIONS } from '@angular/fire';
-import { AngularFireAuthModule } from '@angular/fire/auth';
-import { AngularFirestoreModule } from '@angular/fire/firestore';
-import { environment } from '../../../environments/environment';
 
 describe('AuthService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        AngularFireModule,
-        AngularFireAuthModule,
-        AngularFirestoreModule,
-      ],
+      imports: [],
       providers: [
-        { provide: FIREBASE_OPTIONS, useValue: environment.firebaseConfig },
+        { provide: AngularFirestore, useValue: {} },
         { provide: AngularFireAuth, useValue: { authState: NEVER } },
         { provide: DataStoreService },
         { provide: Router, useValue: {} },

--- a/web-ng/src/app/services/data-store/data-store.service.ts
+++ b/web-ng/src/app/services/data-store/data-store.service.ts
@@ -125,7 +125,9 @@ export class DataStoreService {
       .get()
       .pipe(
         // Fail with error if feature could not be loaded.
-        map(doc => FirebaseDataConverter.toFeature(doc.id, doc.data()!)),
+        map(doc =>
+          FirebaseDataConverter.toFeature(doc.id, doc.data()! as DocumentData)
+        ),
         // Cast to Feature to remove undefined from type. Done as separate
         // map() operation since compiler doesn't recognize cast when defined in
         // previous map() step.
@@ -203,9 +205,11 @@ export class DataStoreService {
       .pipe(
         map(doc => {
           return FirebaseDataConverter.toObservation(
-            project.getLayer(feature.layerId)!.getForm(doc.data()!.formId)!,
+            project
+              .getLayer(feature.layerId)!
+              .getForm((doc.data()! as DocumentData).formId)!,
             doc.id,
-            doc.data()!
+            doc.data()! as DocumentData
           );
         })
       );

--- a/web-ng/src/app/services/layer/layer.service.spec.ts
+++ b/web-ng/src/app/services/layer/layer.service.spec.ts
@@ -15,26 +15,19 @@
  */
 
 import { TestBed } from '@angular/core/testing';
-import { AngularFireModule, FIREBASE_OPTIONS } from '@angular/fire';
-import { AngularFireAuthModule } from '@angular/fire/auth';
-import { AngularFirestoreModule } from '@angular/fire/firestore';
 import { DataStoreService } from '../data-store/data-store.service';
 import { LayerService } from './layer.service';
+import { ProjectService } from './../project/project.service';
 import { RouterTestingModule } from '@angular/router/testing';
 
 describe('LayerService', () => {
   const dataStoreServiceStub: Partial<DataStoreService> = {};
   beforeEach(() =>
     TestBed.configureTestingModule({
-      imports: [
-        AngularFireModule,
-        AngularFireAuthModule,
-        AngularFirestoreModule,
-        RouterTestingModule,
-      ],
+      imports: [RouterTestingModule],
       providers: [
-        { provide: FIREBASE_OPTIONS, useValue: {} },
         { provide: DataStoreService, useValue: dataStoreServiceStub },
+        { provide: ProjectService, useValue: {} },
       ],
     })
   );

--- a/web-ng/src/app/services/router/router.service.spec.ts
+++ b/web-ng/src/app/services/router/router.service.spec.ts
@@ -18,18 +18,13 @@ import { TestBed } from '@angular/core/testing';
 
 import { NavigationService } from './router.service';
 import { Router } from '@angular/router';
-import { AngularFireModule, FIREBASE_OPTIONS } from '@angular/fire';
 
 describe('NavigationService', () => {
   let service: NavigationService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [AngularFireModule],
-      providers: [
-        { provide: FIREBASE_OPTIONS, useValue: {} },
-        { provide: Router, useValue: {} },
-      ],
+      providers: [{ provide: Router, useValue: {} }],
     });
     service = TestBed.inject(NavigationService);
   });


### PR DESCRIPTION
This fixes tests failing locally when run with `ng test`. Several unit tests were trying to use actual Angularfire libs instead of mocks; replaced with mocks where appropriate.

@gyarill PTAL?