### PR TITLE
[Layout dialog] Tab key should skip over "X" when entering multiple choice options

### DIFF
--- a/web-ng/src/app/components/option-editor/option-editor.component.html
+++ b/web-ng/src/app/components/option-editor/option-editor.component.html
@@ -37,6 +37,7 @@
     </div>
     <button
       *ngIf="index"
+      tabindex="-1"
       mat-icon-button
       (click)="onDeleteOption()"
       fxFlexAlign="center"


### PR DESCRIPTION
Closes #565 