### PR TITLE
[Firestore] Workaround for broken rules

### DIFF
--- a/firestore/firestore.rules
+++ b/firestore/firestore.rules
@@ -107,7 +107,7 @@
     match /projects/{projectId} {
       allow read: if canViewProject(projectId, email())
       allow read, write: if canManageProject(projectId, email())
-      allow create, read: if canAccess(email())
+      allow create, read, write: if canAccess(email())
     }
 
     // Apply project-level ACLs and passlist to feature documents.


### PR DESCRIPTION
For some reason "read" is also required in order to write the `acl` object to new projects. 

Builds on #672, workaround for https://github.com/google/ground-android/issues/781.

@gyarill PTAL? @DaoyuT FYI.