### PR TITLE
observation-form: make sure that we do not pop up with warning of unsaved changes right after saving them.

### DIFF
--- a/web-ng/src/app/components/observation-form/observation-form.component.ts
+++ b/web-ng/src/app/components/observation-form/observation-form.component.ts
@@ -115,7 +115,10 @@ export class ObservationFormComponent {
         );
         this.dataStoreService
           .updateObservation(this.projectId!, updatedObservation)
-          .then(() => this.navigateToFeature())
+          .then(() => {
+            this.observationForm?.markAsPristine();
+            return this.navigateToFeature();
+          })
           .catch(() => {
             alert('Observation update failed.');
           });


### PR DESCRIPTION
We achieve it by marking form pristine if saving observation happens. That way we can leave check alone that loads warning when form is dirty because when we mark form pristine it is not dirty anymore

related code introduced in https://github.com/google/ground-platform/commit/6519a1f5b0750b07518a034ba098cb5a0e9588ae (btw. super cool idea!)

I tested by:
1. clicking "save" which does not generate confirm after this change
2. navigating back, clicking different feature, clicking "cancel"  which all still generates confirm popup

closes #675