### PR TITLE
[Import features] Rename remaining import CSV methods

### DIFF
--- a/web-ng/src/app/components/import-dialog/import-dialog.component.ts
+++ b/web-ng/src/app/components/import-dialog/import-dialog.component.ts
@@ -45,19 +45,19 @@ export class ImportDialogComponent {
     });
     dialogRef.afterClosed().subscribe(submit => {
       if (submit) {
-        this.importCsv();
+        this.importFeatures();
       }
     });
   }
 
-  private async importCsv() {
+  private async importFeatures() {
     const files = this.uploadForm.get('file')?.value;
     if (!files || files.length === 0) {
       console.error('File missing');
       return;
     }
     // TODO(#528): Show upload progress and success/error message to user.
-    await this.dataImportService.importCsv(
+    await this.dataImportService.importFeatures(
       this.projectId,
       this.layerId,
       files[0] as File

--- a/web-ng/src/app/components/layer-list-item/layer-list-item.component.html
+++ b/web-ng/src/app/components/layer-list-item/layer-list-item.component.html
@@ -41,7 +41,7 @@ limitations under the License.
         </button>
         <button
           mat-menu-item
-          (click)="onImportCsv()"
+          (click)="onImportFeatures()"
           *ngIf="projectService.canManageProject()"
         >
           <mat-icon>cloud_upload</mat-icon>

--- a/web-ng/src/app/components/layer-list-item/layer-list-item.component.ts
+++ b/web-ng/src/app/components/layer-list-item/layer-list-item.component.ts
@@ -117,7 +117,7 @@ export class LayerListItemComponent implements OnInit, OnDestroy {
     return this.navigationService.selectProject(this.projectId!);
   }
 
-  onImportCsv() {
+  onImportFeatures() {
     if (!this.projectId || !this.layer?.id) {
       return;
     }

--- a/web-ng/src/app/services/data-import/data-import.service.ts
+++ b/web-ng/src/app/services/data-import/data-import.service.ts
@@ -32,7 +32,7 @@ export interface ImportResponse {
 export class DataImportService {
   constructor(private httpClient: HttpClient) {}
 
-  importCsv(
+  importFeatures(
     projectId: string,
     layerId: string,
     file: File


### PR DESCRIPTION
We generalized import to CSV and GeoJSON in #668. Catching up method names with the new broader context.  @parulraheja98 PTAL?