### PR TITLE
[Layer Creation Dialog] Required selector doesn't work

### DIFF
--- a/web-ng/src/app/components/form-field-editor/form-field-editor.component.html
+++ b/web-ng/src/app/components/form-field-editor/form-field-editor.component.html
@@ -90,7 +90,7 @@
     <div
       fxLayout
       fxLayoutAlign="end"
-      (focusout)="onFormBlur()"
+      (keydown.Tab)="onFormBlur()"
       class="question-actions"
     >
       <button type="button" mat-icon-button (click)="onFieldDelete()">


### PR DESCRIPTION
Closes #774 

On tab key press the collapse will occur. The click collapse is handled by HostListener.