### PR TITLE
[Form editor] Leading/trailing spaces in layer name not trimmed on save

### DIFF
--- a/web-ng/src/app/components/layer-dialog/layer-dialog.component.ts
+++ b/web-ng/src/app/components/layer-dialog/layer-dialog.component.ts
@@ -168,7 +168,7 @@ export class LayerDialogComponent implements OnDestroy {
       /* index */ this.layer?.index || -1,
       this.color,
       // TODO: Make layerName Map
-      StringMap({ [this.lang]: this.layerName }),
+      StringMap({ [this.lang]: this.layerName.trim() }),
       forms,
       this.contributorsCanAdd ? ['points'] : []
     );


### PR DESCRIPTION
Closes #771