### PR TITLE
Fix 'process is undefined' error

### DIFF
--- a/web/src/polyfills.ts
+++ b/web/src/polyfills.ts
@@ -76,3 +76,7 @@ import 'zone.js/dist/zone'; // Included with Angular CLI.
 /***************************************************************************************************
  * APPLICATION IMPORTS
  */
+
+(window as any).process = {
+  env: { DEBUG: undefined },
+};


### PR DESCRIPTION
Towards #880 

This was suggested in https://github.com/algolia/algoliasearch-client-javascript/issues/691

The error we get is:

Uncaught ReferenceError: process is not defined
    at Object.AytR (main-es2018.5a360edeeb03a6dea053.js:1:587769)
    at l (runtime-es2018.681bd8a4edb177c86959.js:1:552)
    at Object.zUnb (main-es2018.5a360edeeb03a6dea053.js:1:2483491)
    at l (runtime-es2018.681bd8a4edb177c86959.js:1:552)
    at 0 (main-es2018.5a360edeeb03a6dea053.js:1:41951)
    at l (runtime-es2018.681bd8a4edb177c86959.js:1:552)
    at t (runtime-es2018.681bd8a4edb177c86959.js:1:421)
    at Array.r [as push] (runtime-es2018.681bd8a4edb177c86959.js:1:293)
    at main-es2018.5a360edeeb03a6dea053.js:1:47

this happens when at runtime