### PR TITLE
Fix CD by injecting env variables

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -33,22 +33,22 @@ jobs:
         run: npm install -g @angular/cli > /dev/null
 
       - name: Create firebase-config.ts
-        run: touch src/environments/.firebase-config.ts && echo $FIREBASE_CONFIG > src/environments/.firebase-config.ts
-        shell: bash
+        uses: "finnp/create-file-action@master"
         env:
-          FIREBASE_CONFIG: ${{ secrets.FIREBASE_CONFIG }}
+          FILE_NAME: "src/environments/.firebase-config.ts"
+          FILE_DATA: ${{ secrets.FIREBASE_CONFIG }}
 
       - name: Create google-maps-config.ts
-        run: touch src/environments/.google-maps-config.ts && echo $GOOGLE_MAPS_CONFIG > src/environments/.google-maps-config.ts
-        shell: bash
+        uses: "finnp/create-file-action@master"
         env:
-          FIREBASE_CONFIG: ${{ secrets.GOOGLE_MAPS_CONFIG }}
+          FILE_NAME: "src/environments/.google-maps-config.ts"
+          FILE_DATA: ${{ secrets.GOOGLE_MAPS_CONFIG }}
 
-      - name: Create backend-config.ts
-        run: touch src/environments/.backend-config.ts && echo $BACKEND_CONFIG > src/environments/.backend-config.ts
-        shell: bash
+      - name: Create backend-config.json
+        uses: "finnp/create-file-action@master"
         env:
-          FIREBASE_CONFIG: ${{ secrets.BACKEND_CONFIG }}
+          FILE_NAME: "src/environments/.backend-config.json"
+          FILE_DATA: ${{ secrets.BACKEND_CONFIG }}
 
       - name: Build Angular App
         run: ./build.sh

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -33,13 +33,22 @@ jobs:
         run: npm install -g @angular/cli > /dev/null
 
       - name: Create firebase-config.ts
-        run: echo ${{ secrets.FIREBASE_CONFIG }} > src/environments/.firebase-config.ts
+        run: echo $FIREBASE_CONFIG > src/environments/.firebase-config.ts
+        shell: bash
+        env:
+          FIREBASE_CONFIG: ${{ secrets.FIREBASE_CONFIG }}
 
       - name: Create google-maps-config.ts
-        run: echo ${{ secrets.GOOGLE_MAPS_CONFIG }} > src/environments/.google-maps-config.ts
+        run: echo $GOOGLE_MAPS_CONFIG > src/environments/.google-maps-config.ts
+        shell: bash
+        env:
+          FIREBASE_CONFIG: ${{ secrets.GOOGLE_MAPS_CONFIG }}
 
-      - name: Create backend-config.json
-        run: echo ${{ secrets.BACKEND_CONFIG }} > src/environments/.backend-config.ts
+      - name: Create backend-config.ts
+        run: echo $BACKEND_CONFIG > src/environments/.backend-config.ts
+        shell: bash
+        env:
+          FIREBASE_CONFIG: ${{ secrets.BACKEND_CONFIG }}
 
       - name: Build Angular App
         run: ./build.sh

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -33,19 +33,19 @@ jobs:
         run: npm install -g @angular/cli > /dev/null
 
       - name: Create firebase-config.ts
-        run: echo $FIREBASE_CONFIG > src/environments/.firebase-config.ts
+        run: touch src/environments/.firebase-config.ts && echo $FIREBASE_CONFIG > src/environments/.firebase-config.ts
         shell: bash
         env:
           FIREBASE_CONFIG: ${{ secrets.FIREBASE_CONFIG }}
 
       - name: Create google-maps-config.ts
-        run: echo $GOOGLE_MAPS_CONFIG > src/environments/.google-maps-config.ts
+        run: touch src/environments/.google-maps-config.ts && echo $GOOGLE_MAPS_CONFIG > src/environments/.google-maps-config.ts
         shell: bash
         env:
           FIREBASE_CONFIG: ${{ secrets.GOOGLE_MAPS_CONFIG }}
 
       - name: Create backend-config.ts
-        run: echo $BACKEND_CONFIG > src/environments/.backend-config.ts
+        run: touch src/environments/.backend-config.ts && echo $BACKEND_CONFIG > src/environments/.backend-config.ts
         shell: bash
         env:
           FIREBASE_CONFIG: ${{ secrets.BACKEND_CONFIG }}

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -32,33 +32,21 @@ jobs:
       - name: Install Angular-CLI
         run: npm install -g @angular/cli > /dev/null
 
+      - name: Create firebase-config.ts
+        run: echo ${{ secrets.FIREBASE_CONFIG }} > src/environments/.firebase-config.ts
+
+      - name: Create google-maps-config.ts
+        run: echo ${{ secrets.GOOGLE_MAPS_CONFIG }} > src/environments/.google-maps-config.ts
+
+      - name: Create backend-config.json
+        run: echo ${{ secrets.BACKEND_CONFIG }} > src/environments/.backend-config.ts
+
       - name: Build Angular App
         run: ./build.sh
-        env:
-          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
-          FIREBASE_CONFIG_API_KEY: ${{ secrets.FIREBASE_CONFIG_API_KEY }}
-          FIREBASE_CONFIG_AUTH_DOMAIN: ${{ secrets.FIREBASE_CONFIG_AUTH_DOMAIN }}
-          FIREBASE_CONFIG_DATABASE_URL: ${{ secrets.FIREBASE_CONFIG_DATABASE_URL }}
-          FIREBASE_CONFIG_PROJECT_ID: ${{ secrets.FIREBASE_CONFIG_PROJECT_ID }}
-          FIREBASE_CONFIG_STORAGE_BUCKET: ${{ secrets.FIREBASE_CONFIG_STORAGE_BUCKET }}
-          FIREBASE_CONFIG_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_CONFIG_MESSAGING_SENDER_ID }}
-          FIREBASE_CONFIG_APP_ID: ${{ secrets.FIREBASE_CONFIG_APP_ID }}
-          CLOUD_FUNCTIONS_URL: ${{ secrets.CLOUD_FUNCTIONS_URL }}
-          OFFLINE_BASE_MAP_SOURCES_URL: ${{ secrets.OFFLINE_BASE_MAP_SOURCES_URL }}
+
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_GND_DEV }}"
           channelId: live
           projectId: gnd-dev
-        env:
-          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
-          FIREBASE_CONFIG_API_KEY: ${{ secrets.FIREBASE_CONFIG_API_KEY }}
-          FIREBASE_CONFIG_AUTH_DOMAIN: ${{ secrets.FIREBASE_CONFIG_AUTH_DOMAIN }}
-          FIREBASE_CONFIG_DATABASE_URL: ${{ secrets.FIREBASE_CONFIG_DATABASE_URL }}
-          FIREBASE_CONFIG_PROJECT_ID: ${{ secrets.FIREBASE_CONFIG_PROJECT_ID }}
-          FIREBASE_CONFIG_STORAGE_BUCKET: ${{ secrets.FIREBASE_CONFIG_STORAGE_BUCKET }}
-          FIREBASE_CONFIG_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_CONFIG_MESSAGING_SENDER_ID }}
-          FIREBASE_CONFIG_APP_ID: ${{ secrets.FIREBASE_CONFIG_APP_ID }}
-          CLOUD_FUNCTIONS_URL: ${{ secrets.CLOUD_FUNCTIONS_URL }}
-          OFFLINE_BASE_MAP_SOURCES_URL: ${{ secrets.OFFLINE_BASE_MAP_SOURCES_URL }}

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -35,19 +35,19 @@ jobs:
       - name: Create firebase-config.ts
         uses: "finnp/create-file-action@master"
         env:
-          FILE_NAME: "src/environments/.firebase-config.ts"
+          FILE_NAME: "web/src/environments/.firebase-config.ts"
           FILE_DATA: ${{ secrets.FIREBASE_CONFIG }}
 
       - name: Create google-maps-config.ts
         uses: "finnp/create-file-action@master"
         env:
-          FILE_NAME: "src/environments/.google-maps-config.ts"
+          FILE_NAME: "web/src/environments/.google-maps-config.ts"
           FILE_DATA: ${{ secrets.GOOGLE_MAPS_CONFIG }}
 
       - name: Create backend-config.json
         uses: "finnp/create-file-action@master"
         env:
-          FILE_NAME: "src/environments/.backend-config.json"
+          FILE_NAME: "web/src/environments/.backend-config.json"
           FILE_DATA: ${{ secrets.BACKEND_CONFIG }}
 
       - name: Build Angular App

--- a/web/src/environments/environment.prod.ts
+++ b/web/src/environments/environment.prod.ts
@@ -14,26 +14,17 @@
  * limitations under the License.
  */
 
+import { googleMapsConfig } from './.google-maps-config';
+import { firebaseConfig } from './.firebase-config';
+import { offlineBaseMapSources } from './.backend-config.json';
 import { Env } from './environment-enums';
 
 export const environment = {
   production: true,
-  googleMapsApiKey: process.env.GOOGLE_MAPS_API_KEY,
-  firebase: {
-    apiKey: process.env.FIREBASE_CONFIG_API_KEY,
-    authDomain: process.env.FIREBASE_CONFIG_AUTH_DOMAIN,
-    databaseUrl: process.env.FIREBASE_CONFIG_DATABASE_URL,
-    projectId: process.env.FIREBASE_CONFIG_PROJECT_ID,
-    storageBucket: process.env.FIREBASE_CONFIG_STORAGE_BUCKET,
-    messagingSenderId: process.env.FIREBASE_CONFIG_MESSAGING_SENDER_ID,
-    configAppId: process.env.FIREBASE_CONFIG_APP_ID,
-  },
-  cloudFunctionsUrl: process.env.CLOUD_FUNCTIONS_URL,
-  offlineBaseMapSources: [
-    {
-      url: process.env.OFFLINE_BASE_MAP_SOURCES_URL!,
-    },
-  ],
+  googleMapsApiKey: googleMapsConfig.apiKey,
+  firebase: firebaseConfig,
+  cloudFunctionsUrl: '',
+  offlineBaseMapSources,
   useEmulators: false,
   env: Env.Prod,
 };


### PR DESCRIPTION
It looks like Angular is not able to access the provided env variables. Instead, node.js is able to access them, so we create a small script that injects the variables into the `environments.prod.ts` file.

Towards #925 and #880