### PR TITLE
Implement basic topology classes

### DIFF
--- a/web/src/app/shared/models/geometry/coordinate.ts
+++ b/web/src/app/shared/models/geometry/coordinate.ts
@@ -18,10 +18,7 @@
  * A lightweight class used to store coordinates on the 2-dimensional Cartesian
  * plane.
  *
- * It is distinct from Point, which is a subclass of Geometry. Unlike objects of
- * type Point (which contain additional information such as an envelope, a
- * precision model, and spatial reference system information), a Coordinate only
- * contains ordinate values and accessor methods.
+ * It is distinct from Point, which is a subclass of Geometry.
  *
  * Based on https://locationtech.github.io/jts/javadoc/org/locationtech/jts/geom/Coordinate.html
  */

--- a/web/src/app/shared/models/geometry/coordinate.ts
+++ b/web/src/app/shared/models/geometry/coordinate.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A lightweight class used to store coordinates on the 2-dimensional Cartesian
+ * plane.
+ *
+ * It is distinct from Point, which is a subclass of Geometry. Unlike objects of
+ * type Point (which contain additional information such as an envelope, a
+ * precision model, and spatial reference system information), a Coordinate only
+ * contains ordinate values and accessor methods.
+ *
+ * Based on https://locationtech.github.io/jts/javadoc/org/locationtech/jts/geom/Coordinate.html
+ */
+export class Coordinate {
+  constructor(readonly x: number, readonly y: number) {}
+}

--- a/web/src/app/shared/models/geometry/geometry.ts
+++ b/web/src/app/shared/models/geometry/geometry.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Minimal representation of a planar, linear vector geometry.
+ *
+ * Based on https://locationtech.github.io/jts/javadoc/org/locationtech/jts/geom/Geometry.html
+ */
+export interface Geometry {
+  geometryType: GeometryType;
+}
+
+export enum GeometryType {
+  POINT,
+  LINE_STRING,
+  LINEAR_RING,
+  POLYGON,
+  MULTI_POLYGON,
+}

--- a/web/src/app/shared/models/geometry/geometry.ts
+++ b/web/src/app/shared/models/geometry/geometry.ts
@@ -23,6 +23,9 @@ export interface Geometry {
   geometryType: GeometryType;
 }
 
+/**
+ * An enum representing the type of the geometry instance.
+ */
 export enum GeometryType {
   POINT,
   LINE_STRING,

--- a/web/src/app/shared/models/geometry/line-string.ts
+++ b/web/src/app/shared/models/geometry/line-string.ts
@@ -22,8 +22,8 @@ import { Geometry, GeometryType } from './geometry';
  * or more vertices, along with all points along the linearly-interpolated
  * curves (line segments) between each pair of consecutive vertices. Consecutive
  * vertices may be equal. The line segments in the line may intersect each other
- *  (in other words, the linestring may "curl back" in itself and
- * self-intersect. Linestrings with exactly two identical points are invalid.
+ * (in other words, the linestring may "curl back" in itself and self-intersect.
+ * Linestrings with exactly two identical points are invalid.
  *
  * A linestring is assumed to have either 0 or 2 or more points.
  *

--- a/web/src/app/shared/models/geometry/line-string.ts
+++ b/web/src/app/shared/models/geometry/line-string.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Coordinate } from './coordinate';
+import { Geometry, GeometryType } from './geometry';
+
+/**
+ * Models an OGC-style LineString. A LineString consists of a sequence of two
+ * or more vertices, along with all points along the linearly-interpolated
+ * curves (line segments) between each pair of consecutive vertices. Consecutive
+ * vertices may be equal. The line segments in the line may intersect each other
+ *  (in other words, the linestring may "curl back" in itself and
+ * self-intersect. Linestrings with exactly two identical points are invalid.
+ *
+ * A linestring is assumed to have either 0 or 2 or more points.
+ *
+ * Based on https://locationtech.github.io/jts/javadoc/org/locationtech/jts/geom/LineString.html
+ */
+export class LineString implements Geometry {
+  geometryType = GeometryType.LINE_STRING;
+
+  constructor(readonly points: Coordinate[]) {}
+}

--- a/web/src/app/shared/models/geometry/linear-ring.ts
+++ b/web/src/app/shared/models/geometry/linear-ring.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GeometryType } from './geometry';
+import { LineString } from './line-string';
+
+/**
+ * Models an OGC SFS LinearRing. A LinearRing is a LineString which is both
+ * closed and simple. In other words, the first and last coordinate in the ring
+ * must be equal, and the ring must not self-intersect. Either orientation of
+ * the ring is allowed.
+ *
+ * A ring is assumed to have either 0 or 3 or more points, and the first and
+ * last points are assumed to be equal (in 2D).
+ *
+ * Based on https://locationtech.github.io/jts/javadoc/org/locationtech/jts/geom/LinearRing.html
+ */
+export class LinearRing extends LineString {
+  geometryType = GeometryType.LINEAR_RING;
+}

--- a/web/src/app/shared/models/geometry/multi-polygon.ts
+++ b/web/src/app/shared/models/geometry/multi-polygon.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Polygon } from './polygon';
+import { Geometry, GeometryType } from './geometry';
+
+/**
+ * Models a collection of Polygons.
+ *
+ * As per the OGC SFS specification, the Polygons in a MultiPolygon may not
+ * overlap, and may only touch at single points. This allows the topological
+ * point-set semantics to be well-defined.
+ *
+ * Based on https://locationtech.github.io/jts/javadoc/org/locationtech/jts/geom/MultiPolygon.html
+ */
+export class MultiPolygon implements Geometry {
+  geometryType = GeometryType.MULTI_POLYGON;
+
+  constructor(readonly polygons: Polygon[]) {}
+}

--- a/web/src/app/shared/models/geometry/point.ts
+++ b/web/src/app/shared/models/geometry/point.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Coordinate } from './coordinate';
+import { Geometry, GeometryType } from './geometry';
+
+/**
+ * Represents a single point.
+ *
+ * Based on https://locationtech.github.io/jts/javadoc/org/locationtech/jts/geom/Point.html
+ */
+export class Point implements Geometry {
+  geometryType = GeometryType.POINT;
+
+  constructor(readonly coord: Coordinate) {}
+}

--- a/web/src/app/shared/models/geometry/polygon.ts
+++ b/web/src/app/shared/models/geometry/polygon.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Geometry, GeometryType } from './geometry';
+import { LinearRing } from './linear-ring';
+
+/**
+ * Represents a polygon with linear edges, which may include holes. The outer
+ * boundary (shell) and inner boundaries (holes) of the polygon are represented
+ * by LinearRings. The boundary rings of the polygon may have any orientation.
+ * Polygons are closed, simple geometries by definition.
+ *
+ * The polygon model is assumed to conform to the assertions specified in the
+ * OpenGIS Simple Features Specification for SQL.
+ *
+ * Based on https://locationtech.github.io/jts/javadoc/org/locationtech/jts/geom/Polygon.html
+ */
+export class Polygon implements Geometry {
+  geometryType = GeometryType.POLYGON;
+
+  constructor(readonly shell: LinearRing, readonly holes: LinearRing[]) {}
+}


### PR DESCRIPTION
Work towards #926. These will replace the various LOI implementations, and a reference to Geometry will be added to the main LOI implementation.

@DaoyuT PTAL? 