### PR TITLE
Update enum string to match GeoJson equivalent string representations.

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -91,7 +91,7 @@ Run `ng build` to build the project. The build artifacts will be stored in the
 
 ## Running unit tests
 
-Run `ng test` to execute run tests locally in Chrome using
+Run `npm test` to execute run tests locally in Chrome using
 [Karma](https://karma-runner.github.io) test runner.
 
 ## Running end-to-end tests

--- a/web/src/app/shared/converters/geometry-converter.spec.ts
+++ b/web/src/app/shared/converters/geometry-converter.spec.ts
@@ -24,7 +24,7 @@ import { MultiPolygon } from '../models/geometry/multi-polygon';
 import { Polygon } from '../models/geometry/polygon';
 import { LinearRing } from './../models/geometry/linear-ring';
 import { Point } from './../models/geometry/point';
-import { toGeometry, GEOJSON_GEOMETRY_TYPES } from './geometry-converter';
+import { toGeometry, GEOMETRY_TYPES } from './geometry-converter';
 import { GeoPoint } from 'firebase/firestore';
 import { GeometryType } from '../models/geometry/geometry';
 
@@ -101,7 +101,7 @@ describe('geometry-converter.ts', () => {
       {
         expectation: 'converts map to Point',
         input: {
-          type: GEOJSON_GEOMETRY_TYPES.get(GeometryType.POINT),
+          type: GEOMETRY_TYPES.get(GeometryType.POINT),
           coordinates: new GeoPoint(x, y),
         },
         expectedOutput: point(x, y),
@@ -109,7 +109,7 @@ describe('geometry-converter.ts', () => {
       {
         expectation: 'converts map to Polygon',
         input: {
-          type: GEOJSON_GEOMETRY_TYPES.get(GeometryType.POLYGON),
+          type: GEOMETRY_TYPES.get(GeometryType.POLYGON),
           coordinates: {
             '0': indexedGeoPointMap(path1),
             '1': indexedGeoPointMap(path2),
@@ -120,7 +120,7 @@ describe('geometry-converter.ts', () => {
       {
         expectation: 'converts map to MultiPolygon',
         input: {
-          type: GEOJSON_GEOMETRY_TYPES.get(GeometryType.MULTI_POLYGON),
+          type: GEOMETRY_TYPES.get(GeometryType.MULTI_POLYGON),
           coordinates: {
             '0': {
               '0': indexedGeoPointMap(path1),
@@ -157,20 +157,20 @@ describe('geometry-converter.ts', () => {
       {
         expectation: 'fails on point with missing coordinates',
         input: {
-          type: GEOJSON_GEOMETRY_TYPES.get(GeometryType.POINT),
+          type: GEOMETRY_TYPES.get(GeometryType.POINT),
         },
       },
       {
         expectation: 'fails on point with null coordinates',
         input: {
-          type: GEOJSON_GEOMETRY_TYPES.get(GeometryType.POINT),
+          type: GEOMETRY_TYPES.get(GeometryType.POINT),
           coordinates: null,
         },
       },
       {
         expectation: 'fails on point with wrong coordinates type',
         input: {
-          type: GEOJSON_GEOMETRY_TYPES.get(GeometryType.POINT),
+          type: GEOMETRY_TYPES.get(GeometryType.POINT),
           coordinates: 'Kapow!',
         },
       },

--- a/web/src/app/shared/converters/geometry-converter.spec.ts
+++ b/web/src/app/shared/converters/geometry-converter.spec.ts
@@ -24,7 +24,7 @@ import { MultiPolygon } from '../models/geometry/multi-polygon';
 import { Polygon } from '../models/geometry/polygon';
 import { LinearRing } from './../models/geometry/linear-ring';
 import { Point } from './../models/geometry/point';
-import { toGeometry } from './geometry-converter';
+import { toGeometry, GEOJSON_GEOMETRY_TYPES } from './geometry-converter';
 import { GeoPoint } from 'firebase/firestore';
 import { GeometryType } from '../models/geometry/geometry';
 
@@ -101,7 +101,7 @@ describe('geometry-converter.ts', () => {
       {
         expectation: 'converts map to Point',
         input: {
-          type: GeometryType.POINT,
+          type: GEOJSON_GEOMETRY_TYPES.get(GeometryType.POINT),
           coordinates: new GeoPoint(x, y),
         },
         expectedOutput: point(x, y),
@@ -109,7 +109,7 @@ describe('geometry-converter.ts', () => {
       {
         expectation: 'converts map to Polygon',
         input: {
-          type: GeometryType.POLYGON,
+          type: GEOJSON_GEOMETRY_TYPES.get(GeometryType.POLYGON),
           coordinates: {
             '0': indexedGeoPointMap(path1),
             '1': indexedGeoPointMap(path2),
@@ -120,7 +120,7 @@ describe('geometry-converter.ts', () => {
       {
         expectation: 'converts map to MultiPolygon',
         input: {
-          type: GeometryType.MULTI_POLYGON,
+          type: GEOJSON_GEOMETRY_TYPES.get(GeometryType.MULTI_POLYGON),
           coordinates: {
             '0': {
               '0': indexedGeoPointMap(path1),
@@ -157,20 +157,20 @@ describe('geometry-converter.ts', () => {
       {
         expectation: 'fails on point with missing coordinates',
         input: {
-          type: GeometryType.POINT,
+          type: GEOJSON_GEOMETRY_TYPES.get(GeometryType.POINT),
         },
       },
       {
         expectation: 'fails on point with null coordinates',
         input: {
-          type: GeometryType.POINT,
+          type: GEOJSON_GEOMETRY_TYPES.get(GeometryType.POINT),
           coordinates: null,
         },
       },
       {
         expectation: 'fails on point with wrong coordinates type',
         input: {
-          type: GeometryType.POINT,
+          type: GEOJSON_GEOMETRY_TYPES.get(GeometryType.POINT),
           coordinates: 'Kapow!',
         },
       },

--- a/web/src/app/shared/converters/geometry-converter.ts
+++ b/web/src/app/shared/converters/geometry-converter.ts
@@ -32,7 +32,7 @@ const stringify = (o: Object) => JSON.stringify(o);
  * Maps geometry type enum values to their GeoJson equivalent string
  * representations used in the remote db.
  */
-export const GEOJSON_GEOMETRY_TYPES = Map([
+export const GEOMETRY_TYPES = Map([
   [GeometryType.POINT, 'Point'],
   [GeometryType.POLYGON, 'Polygon'],
   [GeometryType.MULTI_POLYGON, 'MultiPolygon'],
@@ -60,11 +60,11 @@ export function toGeometry(geometry?: any): Geometry | Error {
   }
   try {
     switch (geometry.type) {
-      case GEOJSON_GEOMETRY_TYPES.get(GeometryType.POINT):
+      case GEOMETRY_TYPES.get(GeometryType.POINT):
         return toPoint(geometry.coordinates);
-      case GEOJSON_GEOMETRY_TYPES.get(GeometryType.POLYGON):
+      case GEOMETRY_TYPES.get(GeometryType.POLYGON):
         return toPolygon(geometry.coordinates);
-      case GEOJSON_GEOMETRY_TYPES.get(GeometryType.MULTI_POLYGON):
+      case GEOMETRY_TYPES.get(GeometryType.MULTI_POLYGON):
         return toMultiPolygon(geometry.coordinates);
       default:
         return Error(`Unsupported geometry type ${geometry.type}`);

--- a/web/src/app/shared/converters/geometry-converter.ts
+++ b/web/src/app/shared/converters/geometry-converter.ts
@@ -16,7 +16,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { List } from 'immutable';
+import { List, Map } from 'immutable';
 import { LinearRing } from '../models/geometry/linear-ring';
 import { Point } from '../models/geometry/point';
 import { Polygon } from '../models/geometry/polygon';
@@ -27,6 +27,18 @@ import { MultiPolygon } from './../models/geometry/multi-polygon';
 
 /** Pretty-print objects. */
 const stringify = (o: Object) => JSON.stringify(o);
+
+/**
+ * Maps geometry type enum values to their GeoJson equivalent string
+ * representations used in the remote db.
+ */
+export const GEOJSON_GEOMETRY_TYPES = Map([
+  [GeometryType.POINT, 'Point'],
+  [GeometryType.POLYGON, 'Polygon'],
+  [GeometryType.MULTI_POLYGON, 'MultiPolygon'],
+  [GeometryType.LINE_STRING, 'LineString'],
+  [GeometryType.LINEAR_RING, 'LinearRing'],
+]);
 
 /**
  * Converts remote db representation of a geometry to a geometry object using a
@@ -48,11 +60,11 @@ export function toGeometry(geometry?: any): Geometry | Error {
   }
   try {
     switch (geometry.type) {
-      case GeometryType.POINT:
+      case GEOJSON_GEOMETRY_TYPES.get(GeometryType.POINT):
         return toPoint(geometry.coordinates);
-      case GeometryType.POLYGON:
+      case GEOJSON_GEOMETRY_TYPES.get(GeometryType.POLYGON):
         return toPolygon(geometry.coordinates);
-      case GeometryType.MULTI_POLYGON:
+      case GEOJSON_GEOMETRY_TYPES.get(GeometryType.MULTI_POLYGON):
         return toMultiPolygon(geometry.coordinates);
       default:
         return Error(`Unsupported geometry type ${geometry.type}`);

--- a/web/src/app/shared/converters/loi-converter/loi-data-converter.spec.ts
+++ b/web/src/app/shared/converters/loi-converter/loi-data-converter.spec.ts
@@ -21,7 +21,7 @@ import {
   LocationOfInterest,
   PointOfInterest,
 } from '../../models/loi.model';
-import { toGeometry, GEOJSON_GEOMETRY_TYPES } from '../geometry-converter';
+import { toGeometry, GEOMETRY_TYPES } from '../geometry-converter';
 import { LoiDataConverter } from './loi-data-converter';
 import { Map } from 'immutable';
 import { GeoPoint } from 'firebase/firestore';
@@ -31,7 +31,7 @@ import { Point } from '../../models/geometry/point';
 const x = -42.121;
 const y = 28.482;
 const geoPointData = {
-  type: GEOJSON_GEOMETRY_TYPES.get(GeometryType.POINT),
+  type: GEOMETRY_TYPES.get(GeometryType.POINT),
   coordinates: new GeoPoint(x, y),
 };
 
@@ -153,7 +153,7 @@ describe('loiToJS', () => {
         jobId: 'jobId0',
         geometry: {
           coordinates: new GeoPoint(point.coord.x, point.coord.y),
-          type: GEOJSON_GEOMETRY_TYPES.get(GeometryType.POINT),
+          type: GEOMETRY_TYPES.get(GeometryType.POINT),
         },
       },
     },

--- a/web/src/app/shared/converters/loi-converter/loi-data-converter.spec.ts
+++ b/web/src/app/shared/converters/loi-converter/loi-data-converter.spec.ts
@@ -21,7 +21,7 @@ import {
   LocationOfInterest,
   PointOfInterest,
 } from '../../models/loi.model';
-import { toGeometry } from '../geometry-converter';
+import { toGeometry, GEOJSON_GEOMETRY_TYPES } from '../geometry-converter';
 import { LoiDataConverter } from './loi-data-converter';
 import { Map } from 'immutable';
 import { GeoPoint } from 'firebase/firestore';
@@ -31,7 +31,7 @@ import { Point } from '../../models/geometry/point';
 const x = -42.121;
 const y = 28.482;
 const geoPointData = {
-  type: GeometryType.POINT,
+  type: GEOJSON_GEOMETRY_TYPES.get(GeometryType.POINT),
   coordinates: new GeoPoint(x, y),
 };
 
@@ -153,7 +153,7 @@ describe('loiToJS', () => {
         jobId: 'jobId0',
         geometry: {
           coordinates: new GeoPoint(point.coord.x, point.coord.y),
-          type: GeometryType.POINT,
+          type: GEOJSON_GEOMETRY_TYPES.get(GeometryType.POINT),
         },
       },
     },

--- a/web/src/app/shared/converters/loi-converter/loi-data-converter.ts
+++ b/web/src/app/shared/converters/loi-converter/loi-data-converter.ts
@@ -77,6 +77,7 @@ export class LoiDataConverter {
   public static loiToJS(loi: LocationOfInterest): {} | Error {
     // TODO: Set audit info (created / last modified user and timestamp).
     if (loi.geometry instanceof Point) {
+      // TODO: Add geometryToJS converters in geometry-converter.ts call it from here. Then GEOJSON_GEOMETRY_TYPES can be local.
       const { jobId, geometry } = loi;
       return {
         jobId,

--- a/web/src/app/shared/converters/loi-converter/loi-data-converter.ts
+++ b/web/src/app/shared/converters/loi-converter/loi-data-converter.ts
@@ -23,7 +23,7 @@ import {
 import { Map } from 'immutable';
 import { GeoPoint } from 'firebase/firestore';
 import { Geometry } from '../../models/geometry/geometry';
-import { toGeometry, GEOJSON_GEOMETRY_TYPES } from './../geometry-converter';
+import { toGeometry, GEOMETRY_TYPES } from './../geometry-converter';
 import { Point } from '../../models/geometry/point';
 
 /**
@@ -77,13 +77,13 @@ export class LoiDataConverter {
   public static loiToJS(loi: LocationOfInterest): {} | Error {
     // TODO: Set audit info (created / last modified user and timestamp).
     if (loi.geometry instanceof Point) {
-      // TODO: Add geometryToJS converters in geometry-converter.ts call it from here. Then GEOJSON_GEOMETRY_TYPES can be local.
+      // TODO: Add geometryToJS converters in geometry-converter.ts call it from here. Then GEOMETRY_TYPES can be local.
       const { jobId, geometry } = loi;
       return {
         jobId,
         geometry: {
           coordinates: new GeoPoint(geometry.coord.x, geometry.coord.y),
-          type: GEOJSON_GEOMETRY_TYPES.get(geometry.geometryType),
+          type: GEOMETRY_TYPES.get(geometry.geometryType),
         },
       };
     } else if (loi instanceof GeoJsonLocationOfInterest) {

--- a/web/src/app/shared/converters/loi-converter/loi-data-converter.ts
+++ b/web/src/app/shared/converters/loi-converter/loi-data-converter.ts
@@ -23,7 +23,7 @@ import {
 import { Map } from 'immutable';
 import { GeoPoint } from 'firebase/firestore';
 import { Geometry } from '../../models/geometry/geometry';
-import { toGeometry } from './../geometry-converter';
+import { toGeometry, GEOJSON_GEOMETRY_TYPES } from './../geometry-converter';
 import { Point } from '../../models/geometry/point';
 
 /**
@@ -82,7 +82,7 @@ export class LoiDataConverter {
         jobId,
         geometry: {
           coordinates: new GeoPoint(geometry.coord.x, geometry.coord.y),
-          type: geometry.geometryType,
+          type: GEOJSON_GEOMETRY_TYPES.get(geometry.geometryType),
         },
       };
     } else if (loi instanceof GeoJsonLocationOfInterest) {

--- a/web/src/app/shared/models/geometry/geometry.ts
+++ b/web/src/app/shared/models/geometry/geometry.ts
@@ -27,9 +27,9 @@ export interface Geometry {
  * An enum representing the type of the geometry instance.
  */
 export enum GeometryType {
-  POINT = 'POINT',
-  LINE_STRING = 'LINE_STRING',
-  LINEAR_RING = 'LINEAR_RING',
-  POLYGON = 'POLYGON',
-  MULTI_POLYGON = 'MULTI_POLYGON',
+  POINT = 'Point',
+  LINE_STRING = 'LineString',
+  LINEAR_RING = 'LinearRing',
+  POLYGON = 'Polygon',
+  MULTI_POLYGON = 'MultiPolygon',
 }

--- a/web/src/app/shared/models/geometry/geometry.ts
+++ b/web/src/app/shared/models/geometry/geometry.ts
@@ -27,9 +27,9 @@ export interface Geometry {
  * An enum representing the type of the geometry instance.
  */
 export enum GeometryType {
-  POINT = 'Point',
-  LINE_STRING = 'LineString',
-  LINEAR_RING = 'LinearRing',
-  POLYGON = 'Polygon',
-  MULTI_POLYGON = 'MultiPolygon',
+  POINT = 'POINT',
+  LINE_STRING = 'LINE_STRING',
+  LINEAR_RING = 'LINEAR_RING',
+  POLYGON = 'POLYGON',
+  MULTI_POLYGON = 'MULTI_POLYGON',
 }


### PR DESCRIPTION
Background:

#952 made change to delete `GEOJSON_GEOMETRY_TYPES` in `geometry-converter.ts`
![image](https://user-images.githubusercontent.com/10445677/201790128-f5332380-d85c-4dab-9a20-0de91052704a.png)
and added string in `GeometryType` enum
![image](https://user-images.githubusercontent.com/10445677/201790247-61074bc7-4eef-4f62-a8f5-8c768370bd1f.png)
but it does not match the equivalent string representations in GeoJson

Want LGTM from both @nwkotto & @gino-m 