### PR TITLE
Geometry model refactor: Added supported for polygons and multipolygons

### DIFF
--- a/web/src/app/components/loi-panel-header/loi-panel-header.component.ts
+++ b/web/src/app/components/loi-panel-header/loi-panel-header.component.ts
@@ -29,10 +29,9 @@ import { DialogService } from 'app/services/dialog/dialog.service';
 import { DataStoreService } from 'app/services/data-store/data-store.service';
 import { NavigationService } from 'app/services/navigation/navigation.service';
 import { Subscription } from 'rxjs';
-import { GeoJsonLocationOfInterest } from 'app/models/loi.model';
 import { LocationOfInterestService } from 'app/services/loi/loi.service';
 import { Map } from 'immutable';
-import { Point } from 'app/models/geometry/point';
+import { GeometryType, geometryTypeLabel } from 'app/models/geometry/geometry';
 @Component({
   selector: 'ground-loi-panel-header',
   templateUrl: './loi-panel-header.component.html',
@@ -47,9 +46,9 @@ export class LocationOfInterestPanelHeaderComponent
   pinUrl: SafeUrl;
   readonly loiType = LocationOfInterestType;
   subscription: Subscription = new Subscription();
-  loiTypeValue?: LocationOfInterestType;
   private readonly CAPTION_PROPERTIES = ['caption', 'label', 'name'];
   private readonly ID_PROPERTIES = ['id', 'identifier', 'id_prod'];
+  private loiGeometryType?: GeometryType;
   private loiProperties?: Map<string, string | number>;
 
   constructor(
@@ -63,11 +62,7 @@ export class LocationOfInterestPanelHeaderComponent
     this.pinUrl = sanitizer.bypassSecurityTrustUrl(getPinImageSource());
     this.subscription.add(
       loiService.getSelectedLocationOfInterest$().subscribe(loi => {
-        if (loi instanceof GeoJsonLocationOfInterest) {
-          this.loiTypeValue = LocationOfInterestType.Polygon;
-        } else if (loi.geometry instanceof Point) {
-          this.loiTypeValue = LocationOfInterestType.Point;
-        }
+        this.loiGeometryType = loi.geometry?.geometryType;
         this.loiProperties = loi.properties;
       })
     );
@@ -138,8 +133,8 @@ export class LocationOfInterestPanelHeaderComponent
     if (caption) {
       return caption;
     }
-    const loiType =
-      this.loiTypeValue === LocationOfInterestType.Point ? 'Point' : 'Polygon';
+    const loiType = geometryTypeLabel(this.loiGeometryType);
+
     const id = this.findProperty(this.ID_PROPERTIES);
     if (id) {
       return loiType + ' ' + id;
@@ -169,4 +164,5 @@ export class LocationOfInterestPanelHeaderComponent
 enum LocationOfInterestType {
   Point = 'POINT',
   Polygon = 'POLYGON',
+  MultiPolygon = 'MULTIPOLYGON',
 }

--- a/web/src/app/components/map/map.component.spec.ts
+++ b/web/src/app/components/map/map.component.spec.ts
@@ -29,14 +29,11 @@ import { NavigationService } from 'app/services/navigation/navigation.service';
 import { Survey } from 'app/models/survey.model';
 import {
   LocationOfInterest,
-  GeoJsonLocationOfInterest,
-  AreaOfInterest,
   GenericLocationOfInterest,
 } from 'app/models/loi.model';
 import { Map, List } from 'immutable';
 import { Job } from 'app/models/job.model';
 import { BehaviorSubject, of } from 'rxjs';
-import { GeoPoint } from 'firebase/firestore';
 import { GoogleMapsModule } from '@angular/google-maps';
 import { urlPrefix } from 'app/components/map/ground-pin';
 import {
@@ -45,6 +42,16 @@ import {
 } from 'app/services/drawing-tools/drawing-tools.service';
 import { Point } from 'app/models/geometry/point';
 import { Coordinate } from 'app/models/geometry/coordinate';
+import { Polygon } from 'app/models/geometry/polygon';
+import { LinearRing } from 'app/models/geometry/linear-ring';
+import { MultiPolygon } from 'app/models/geometry/multi-polygon';
+
+function polygonShellCoordsToPolygon(coordinates: number[][]): Polygon {
+  const coordinateInstances = coordinates.map(
+    ([longitude, latitude]) => new Coordinate(longitude, latitude)
+  );
+  return new Polygon(new LinearRing(List(coordinateInstances)), List());
+}
 
 describe('MapComponent', () => {
   let component: MapComponent;
@@ -64,8 +71,8 @@ describe('MapComponent', () => {
   const poiId2 = 'poi002';
   const poiId3 = 'poi003';
   const poiId4 = 'poi004';
-  const geoJsonLoiId1 = 'geo_json_loi001';
-  const aoiId1 = 'aoi001';
+  const polygonLoiId1 = 'polygon_loi001';
+  const multipolygonLoiId1 = 'multipolygon_loi001';
   const jobId1 = 'job001';
   const jobId2 = 'job002';
   const jobColor1 = 'red';
@@ -116,38 +123,37 @@ describe('MapComponent', () => {
     new Point(new Coordinate(45, 45)),
     Map()
   );
-  const geoJson1 = {
-    type: 'FeatureCollection',
-    features: [
-      {
-        type: 'Feature',
-        geometry: {
-          type: 'Polygon',
-          coordinates: [
-            [
-              [0, 0],
-              [10, 0],
-              [10, 10],
-              [0, 10],
-              [0, 0],
-            ],
-          ],
-        },
-      },
-    ],
-  };
-  const geoJsonLoi1 = new GeoJsonLocationOfInterest(
-    geoJsonLoiId1,
+  const polygon1ShellCoordinates = [
+    [0, 0],
+    [10, 0],
+    [10, 10],
+    [0, 10],
+    [0, 0],
+  ];
+  const polygon2ShellCoordinates = [
+    [-10, -10],
+    [-10, 20],
+    [20, 20],
+    [20, -10],
+    [-10, -10],
+  ];
+  const polygonLoi1 = new GenericLocationOfInterest(
+    polygonLoiId1,
     jobId1,
-    geoJson1
+    polygonShellCoordsToPolygon(polygon1ShellCoordinates),
+    Map()
   );
-  const aoi1 = new AreaOfInterest(aoiId1, jobId2, [
-    new GeoPoint(-10, -10),
-    new GeoPoint(20, -10),
-    new GeoPoint(20, 20),
-    new GeoPoint(-10, 20),
-    new GeoPoint(-10, -10),
-  ]);
+  const multipolygonLoi1 = new GenericLocationOfInterest(
+    multipolygonLoiId1,
+    jobId1,
+    new MultiPolygon(
+      List([
+        polygonShellCoordsToPolygon(polygon1ShellCoordinates),
+        polygonShellCoordsToPolygon(polygon2ShellCoordinates),
+      ])
+    ),
+    Map()
+  );
 
   beforeEach(waitForAsync(() => {
     surveyServiceSpy = jasmine.createSpyObj<SurveyService>('SurveyService', [
@@ -160,7 +166,7 @@ describe('MapComponent', () => {
       ['getLocationsOfInterest$', 'updatePoint', 'addPoint']
     );
     mockLois$ = new BehaviorSubject<List<LocationOfInterest>>(
-      List<LocationOfInterest>([poi1, poi2, geoJsonLoi1, aoi1])
+      List<LocationOfInterest>([poi1, poi2, polygonLoi1])
     );
     loiServiceSpy.getLocationsOfInterest$.and.returnValue(mockLois$);
 
@@ -232,23 +238,36 @@ describe('MapComponent', () => {
     expect(marker2.getMap()).toEqual(component.map.googleMap!);
   });
 
-  it('should render polygons on map - geojson loi', () => {
-    const polygon = component.polygons.get(geoJsonLoiId1)!;
+  it('should render polygons on map - polygon loi', () => {
+    const [polygon] = component.polygons.get(polygonLoiId1)!;
     assertPolygonPaths(polygon, [
       [
         new google.maps.LatLng(0, 0),
         new google.maps.LatLng(0, 10),
         new google.maps.LatLng(10, 10),
         new google.maps.LatLng(10, 0),
+        new google.maps.LatLng(0, 0),
       ],
     ]);
     assertPolygonStyle(polygon, jobColor1, 3);
     expect(polygon.getMap()).toEqual(component.map.googleMap!);
   });
 
-  it('should render polygons on map - polygon loi', () => {
-    const polygon = component.polygons.get(aoiId1)!;
-    assertPolygonPaths(polygon, [
+  it('should render polygons on map - multipolygon loi', fakeAsync(() => {
+    mockLois$.next(List<LocationOfInterest>([multipolygonLoi1]));
+    tick();
+
+    const [polygon1, polygon2] = component.polygons.get(multipolygonLoiId1)!;
+    assertPolygonPaths(polygon1, [
+      [
+        new google.maps.LatLng(0, 0),
+        new google.maps.LatLng(0, 10),
+        new google.maps.LatLng(10, 10),
+        new google.maps.LatLng(10, 0),
+        new google.maps.LatLng(0, 0),
+      ],
+    ]);
+    assertPolygonPaths(polygon2, [
       [
         new google.maps.LatLng(-10, -10),
         new google.maps.LatLng(20, -10),
@@ -257,12 +276,14 @@ describe('MapComponent', () => {
         new google.maps.LatLng(-10, -10),
       ],
     ]);
-    assertPolygonStyle(polygon, jobColor2, 3);
-    expect(polygon.getMap()).toEqual(component.map.googleMap!);
-  });
+    assertPolygonStyle(polygon1, jobColor1, 3);
+    assertPolygonStyle(polygon2, jobColor1, 3);
+    expect(polygon1.getMap()).toEqual(component.map.googleMap!);
+    expect(polygon2.getMap()).toEqual(component.map.googleMap!);
+  }));
 
   it('should update lois when backend lois update', fakeAsync(() => {
-    mockLois$.next(List<LocationOfInterest>([poi1, poi3, geoJsonLoi1]));
+    mockLois$.next(List<LocationOfInterest>([poi1, poi3, polygonLoi1]));
     tick();
 
     expect(component.markers.size).toEqual(2);
@@ -275,13 +296,14 @@ describe('MapComponent', () => {
     assertMarkerIcon(marker2, jobColor2, 30);
     expect(marker2.getMap()).toEqual(component.map.googleMap!);
     expect(component.polygons.size).toEqual(1);
-    const polygon = component.polygons.get(geoJsonLoiId1)!;
+    const [polygon] = component.polygons.get(polygonLoiId1)!;
     assertPolygonPaths(polygon, [
       [
         new google.maps.LatLng(0, 0),
         new google.maps.LatLng(0, 10),
         new google.maps.LatLng(10, 10),
         new google.maps.LatLng(10, 0),
+        new google.maps.LatLng(0, 0),
       ],
     ]);
     assertPolygonStyle(polygon, jobColor1, 3);
@@ -305,22 +327,11 @@ describe('MapComponent', () => {
     assertMarkerIcon(marker1, jobColor1, 50);
   }));
 
-  it('should select loi when polygon is clicked', () => {
-    const polygon = component.polygons.get(aoiId1)!;
-    google.maps.event.trigger(polygon, 'click', {
-      latLng: new google.maps.LatLng(-9, -9),
-    });
-
-    expect(
-      navigationServiceSpy.selectLocationOfInterest
-    ).toHaveBeenCalledOnceWith(aoiId1);
-  });
-
   it('should enlarge the stroke weight of the polygon when loi is selected', fakeAsync(() => {
-    mockLocationOfInterestId$.next(geoJsonLoiId1);
+    mockLocationOfInterestId$.next(polygonLoiId1);
     tick();
 
-    const polygon = component.polygons.get(geoJsonLoiId1)!;
+    const [polygon] = component.polygons.get(polygonLoiId1)!;
     assertPolygonStyle(polygon, jobColor1, 6);
   }));
 
@@ -410,7 +421,7 @@ describe('MapComponent', () => {
     google.maps.event.trigger(marker, 'dragstart', {
       latLng: new google.maps.LatLng(1.23, 4.56),
     });
-    const polygon = component.polygons.get(geoJsonLoiId1)!;
+    const [polygon] = component.polygons.get(polygonLoiId1)!;
     google.maps.event.trigger(polygon, 'click');
 
     expect(navigationServiceSpy.selectLocationOfInterest).toHaveBeenCalledTimes(
@@ -504,18 +515,21 @@ describe('MapComponent', () => {
   }));
 
   it('should pop up dialog when overlapping polygons are clicked', fakeAsync(() => {
-    const polygon = component.polygons.get(geoJsonLoiId1)!;
+    mockLois$.next(List<LocationOfInterest>([polygonLoi1, multipolygonLoi1]));
+    tick();
+
+    const [polygon] = component.polygons.get(polygonLoiId1)!;
     google.maps.event.trigger(polygon, 'click', {
-      latLng: new google.maps.LatLng(0, 0),
+      latLng: new google.maps.LatLng(2, 2),
     });
-    mockDialogAfterClosed$.next(aoiId1);
+    mockDialogAfterClosed$.next(multipolygonLoiId1);
     tick();
 
     expect(dialogSpy.open).toHaveBeenCalledTimes(1);
     expect(dialogRefSpy.afterClosed).toHaveBeenCalledTimes(1);
     expect(
       navigationServiceSpy.selectLocationOfInterest
-    ).toHaveBeenCalledOnceWith(aoiId1);
+    ).toHaveBeenCalledOnceWith(multipolygonLoiId1);
   }));
 
   it('should add marker when map clicked and edit mode is "AddPoint"', fakeAsync(() => {

--- a/web/src/app/converters/loi-converter/loi-data-converter.ts
+++ b/web/src/app/converters/loi-converter/loi-data-converter.ts
@@ -74,6 +74,9 @@ export class LoiDataConverter {
     }
   }
 
+  // TODO(Nick): Add polygon / multipolygon conversion, remove AreaOfInterest
+  // and GeoJsonLocationOfInterest. This may not be urgent, as only point
+  // conversion seems to be used on the frontend.
   public static loiToJS(loi: LocationOfInterest): {} | Error {
     // TODO: Set audit info (created / last modified user and timestamp).
     if (loi.geometry instanceof Point) {

--- a/web/src/app/models/geometry/geometry.ts
+++ b/web/src/app/models/geometry/geometry.ts
@@ -33,3 +33,14 @@ export enum GeometryType {
   POLYGON = 'POLYGON',
   MULTI_POLYGON = 'MULTI_POLYGON',
 }
+
+/** A label for a given geometry type. Defaults to 'Polygon'. */
+export function geometryTypeLabel(geometryType?: GeometryType): string {
+  if (geometryType === GeometryType.POINT) {
+    return 'Point';
+  }
+  if (geometryType === GeometryType.MULTI_POLYGON) {
+    return 'Multipolygon';
+  }
+  return 'Polygon';
+}


### PR DESCRIPTION
- Removed references to GeoJsonLocationOfInterest and AreaOfInterest in the map component
- Added support for Polygon and Multipolygon geometry types, refactoring the map component to support multiple polygons associated with an LOI instead of just one.
- Moved the logic for generating geometry type labels from loi-panel-header to geometry.ts