### PR TITLE
Add FAO to shared copyright

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2022 The Ground Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2021 The Ground Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,8 @@
+# This is the list of Ground's significant contributors.
+#
+# This does not necessarily list everyone who has contributed code,
+# especially since many employees of one corporation may be contributing.
+# To see the full list of contributors, see the revision history in
+# source control.
+Google LLC
+FAO

--- a/architecture-docs/firebase-implementation-overview.md
+++ b/architecture-docs/firebase-implementation-overview.md
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2021 Google LLC
+  Copyright 2021 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/architecture-docs/platform-architecture.md
+++ b/architecture-docs/platform-architecture.md
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2021 Google LLC
+  Copyright 2021 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/architecture-docs/web-app-architecture.md
+++ b/architecture-docs/web-app-architecture.md
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2021 Google LLC
+  Copyright 2021 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/firestore/firestore.rules
+++ b/firestore/firestore.rules
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/functions/src/common/auth.ts
+++ b/functions/src/common/auth.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/functions/src/common/context.ts
+++ b/functions/src/common/context.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/functions/src/common/datastore.ts
+++ b/functions/src/common/datastore.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2018 Google LLC
+ * Copyright 2018 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/functions/src/export-csv.ts
+++ b/functions/src/export-csv.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/functions/src/handlers.ts
+++ b/functions/src/handlers.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/functions/src/import-csv.ts
+++ b/functions/src/import-csv.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/functions/src/import-geojson.ts
+++ b/functions/src/import-geojson.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2021 Google LLC
+ * Copyright 2021 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2018 Google LLC
+ * Copyright 2018 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/functions/src/on-write-submission.spec.ts
+++ b/functions/src/on-write-submission.spec.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/functions/src/on-write-submission.ts
+++ b/functions/src/on-write-submission.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/functions/src/on-write-survey.ts
+++ b/functions/src/on-write-survey.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2022 Google LLC
+ * Copyright 2022 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/functions/src/profile-refresh.ts
+++ b/functions/src/profile-refresh.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/functions/src/session-login.ts
+++ b/functions/src/session-login.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/functions/src/testing/mock-firestore.ts
+++ b/functions/src/testing/mock-firestore.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/e2e/protractor.conf.js
+++ b/web/e2e/protractor.conf.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/e2e/src/app.e2e-spec.ts
+++ b/web/e2e/src/app.e2e-spec.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/e2e/src/app.po.ts
+++ b/web/e2e/src/app.po.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/karma.conf.js
+++ b/web/karma.conf.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/posttest.sh
+++ b/web/posttest.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2021 Google LLC
+# Copyright 2021 The Ground Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/web/precheck.sh
+++ b/web/precheck.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2022 Google LLC
+# Copyright 2022 The Ground Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/web/pretest.sh
+++ b/web/pretest.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2021 Google LLC
+# Copyright 2021 The Ground Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/web/src/app/app.component.html
+++ b/web/src/app/app.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2019 Google LLC
+  Copyright 2019 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/app.component.ts
+++ b/web/src/app/app.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/app.css
+++ b/web/src/app/app.css
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/app.module.ts
+++ b/web/src/app/app.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/app.spec.ts
+++ b/web/src/app/app.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/confirmation-dialog/confirmation-dialog.component.css
+++ b/web/src/app/components/confirmation-dialog/confirmation-dialog.component.css
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/confirmation-dialog/confirmation-dialog.component.html
+++ b/web/src/app/components/confirmation-dialog/confirmation-dialog.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2020 Google LLC
+  Copyright 2020 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/components/confirmation-dialog/confirmation-dialog.component.spec.ts
+++ b/web/src/app/components/confirmation-dialog/confirmation-dialog.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/confirmation-dialog/confirmation-dialog.component.ts
+++ b/web/src/app/components/confirmation-dialog/confirmation-dialog.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/header/current-user-widget/account-popup/account-popup.component.html
+++ b/web/src/app/components/header/current-user-widget/account-popup/account-popup.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2020 Google LLC
+  Copyright 2020 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/components/header/current-user-widget/account-popup/account-popup.component.scss
+++ b/web/src/app/components/header/current-user-widget/account-popup/account-popup.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/header/current-user-widget/account-popup/account-popup.component.spec.ts
+++ b/web/src/app/components/header/current-user-widget/account-popup/account-popup.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/header/current-user-widget/account-popup/account-popup.component.ts
+++ b/web/src/app/components/header/current-user-widget/account-popup/account-popup.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/header/current-user-widget/account-popup/account-popup.module.ts
+++ b/web/src/app/components/header/current-user-widget/account-popup/account-popup.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/header/current-user-widget/current-user-widget.component.html
+++ b/web/src/app/components/header/current-user-widget/current-user-widget.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2022 Google LLC
+  Copyright 2022 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/components/header/current-user-widget/current-user-widget.component.scss
+++ b/web/src/app/components/header/current-user-widget/current-user-widget.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/header/current-user-widget/current-user-widget.component.spec.ts
+++ b/web/src/app/components/header/current-user-widget/current-user-widget.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/header/current-user-widget/current-user-widget.component.ts
+++ b/web/src/app/components/header/current-user-widget/current-user-widget.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/header/current-user-widget/current-user-widget.module.ts
+++ b/web/src/app/components/header/current-user-widget/current-user-widget.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/header/header.component.html
+++ b/web/src/app/components/header/header.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2020 Google LLC
+  Copyright 2020 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/components/header/header.component.scss
+++ b/web/src/app/components/header/header.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/header/header.component.spec.ts
+++ b/web/src/app/components/header/header.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/header/header.component.ts
+++ b/web/src/app/components/header/header.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/header/header.module.ts
+++ b/web/src/app/components/header/header.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/import-dialog/import-dialog.component.html
+++ b/web/src/app/components/import-dialog/import-dialog.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2020 Google LLC
+  Copyright 2020 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/components/import-dialog/import-dialog.component.scss
+++ b/web/src/app/components/import-dialog/import-dialog.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/import-dialog/import-dialog.component.spec.ts
+++ b/web/src/app/components/import-dialog/import-dialog.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/import-dialog/import-dialog.component.ts
+++ b/web/src/app/components/import-dialog/import-dialog.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/import-dialog/import-dialog.module.ts
+++ b/web/src/app/components/import-dialog/import-dialog.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/inline-editor/inline-editor.component.html
+++ b/web/src/app/components/inline-editor/inline-editor.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2020 Google LLC
+  Copyright 2020 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/components/inline-editor/inline-editor.component.scss
+++ b/web/src/app/components/inline-editor/inline-editor.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/inline-editor/inline-editor.component.ts
+++ b/web/src/app/components/inline-editor/inline-editor.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/inline-editor/inline-editor.module.ts
+++ b/web/src/app/components/inline-editor/inline-editor.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/job-list-item/job-list-item.component.html
+++ b/web/src/app/components/job-list-item/job-list-item.component.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2021 Google LLC
+Copyright 2021 The Ground Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/web/src/app/components/job-list-item/job-list-item.component.scss
+++ b/web/src/app/components/job-list-item/job-list-item.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/job-list-item/job-list-item.component.spec.ts
+++ b/web/src/app/components/job-list-item/job-list-item.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/job-list-item/job-list-item.component.ts
+++ b/web/src/app/components/job-list-item/job-list-item.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/job-list-item/job-list-item.module.ts
+++ b/web/src/app/components/job-list-item/job-list-item.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/share-dialog/share-dialog.component.html
+++ b/web/src/app/components/share-dialog/share-dialog.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2020 Google LLC
+  Copyright 2020 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/components/share-dialog/share-dialog.component.scss
+++ b/web/src/app/components/share-dialog/share-dialog.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/share-dialog/share-dialog.component.spec.ts
+++ b/web/src/app/components/share-dialog/share-dialog.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/share-dialog/share-dialog.component.ts
+++ b/web/src/app/components/share-dialog/share-dialog.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/share-dialog/share-dialog.module.ts
+++ b/web/src/app/components/share-dialog/share-dialog.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/share-list/share-list.component.html
+++ b/web/src/app/components/share-list/share-list.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2023 Google LLC
+  Copyright 2023 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/components/share-list/share-list.component.scss
+++ b/web/src/app/components/share-list/share-list.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/share-list/share-list.component.spec.ts
+++ b/web/src/app/components/share-list/share-list.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/share-list/share-list.component.ts
+++ b/web/src/app/components/share-list/share-list.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/share-list/share-list.module.ts
+++ b/web/src/app/components/share-list/share-list.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/share-survey/share-survey.component.html
+++ b/web/src/app/components/share-survey/share-survey.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2023 Google LLC
+  Copyright 2023 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/components/share-survey/share-survey.module.ts
+++ b/web/src/app/components/share-survey/share-survey.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/sign-in-page/sign-in-page.component.html
+++ b/web/src/app/components/sign-in-page/sign-in-page.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2020 Google LLC
+  Copyright 2020 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/components/sign-in-page/sign-in-page.component.scss
+++ b/web/src/app/components/sign-in-page/sign-in-page.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/sign-in-page/sign-in-page.component.spec.ts
+++ b/web/src/app/components/sign-in-page/sign-in-page.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/sign-in-page/sign-in-page.component.ts
+++ b/web/src/app/components/sign-in-page/sign-in-page.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/sign-in-page/sign-in-page.module.ts
+++ b/web/src/app/components/sign-in-page/sign-in-page.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/survey-list/survey-list.component.html
+++ b/web/src/app/components/survey-list/survey-list.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2021 Google LLC
+  Copyright 2021 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/components/survey-list/survey-list.component.scss
+++ b/web/src/app/components/survey-list/survey-list.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2021 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/survey-list/survey-list.component.spec.ts
+++ b/web/src/app/components/survey-list/survey-list.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2021 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/survey-list/survey-list.component.ts
+++ b/web/src/app/components/survey-list/survey-list.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2021 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/survey-list/survey-list.module.ts
+++ b/web/src/app/components/survey-list/survey-list.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2021 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/user-avatar/user-avatar.component.html
+++ b/web/src/app/components/user-avatar/user-avatar.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2020 Google LLC
+  Copyright 2020 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/components/user-avatar/user-avatar.component.scss
+++ b/web/src/app/components/user-avatar/user-avatar.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/user-avatar/user-avatar.component.spec.ts
+++ b/web/src/app/components/user-avatar/user-avatar.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/user-avatar/user-avatar.component.ts
+++ b/web/src/app/components/user-avatar/user-avatar.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/components/user-avatar/user-avatar.module.ts
+++ b/web/src/app/components/user-avatar/user-avatar.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/converters/firebase-data-converter.spec.ts
+++ b/web/src/app/converters/firebase-data-converter.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/converters/firebase-data-converter.ts
+++ b/web/src/app/converters/firebase-data-converter.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/converters/geometry-converter.spec.ts
+++ b/web/src/app/converters/geometry-converter.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/converters/geometry-converter.ts
+++ b/web/src/app/converters/geometry-converter.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/converters/loi-converter/loi-data-converter.spec.ts
+++ b/web/src/app/converters/loi-converter/loi-data-converter.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/converters/loi-converter/loi-data-converter.ts
+++ b/web/src/app/converters/loi-converter/loi-data-converter.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/models/acl-entry.model.ts
+++ b/web/src/app/models/acl-entry.model.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/models/audit-info.model.ts
+++ b/web/src/app/models/audit-info.model.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/models/copiable.ts
+++ b/web/src/app/models/copiable.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/models/geometry/coordinate.ts
+++ b/web/src/app/models/geometry/coordinate.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/models/geometry/geometry.ts
+++ b/web/src/app/models/geometry/geometry.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/models/geometry/line-string.ts
+++ b/web/src/app/models/geometry/line-string.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/models/geometry/linear-ring.ts
+++ b/web/src/app/models/geometry/linear-ring.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/models/geometry/multi-polygon.ts
+++ b/web/src/app/models/geometry/multi-polygon.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/models/geometry/point.ts
+++ b/web/src/app/models/geometry/point.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/models/geometry/polygon.ts
+++ b/web/src/app/models/geometry/polygon.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/models/job.model.ts
+++ b/web/src/app/models/job.model.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/models/loi.model.ts
+++ b/web/src/app/models/loi.model.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/models/offline-base-map-source.ts
+++ b/web/src/app/models/offline-base-map-source.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/models/role.model.ts
+++ b/web/src/app/models/role.model.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/models/submission/result.model.ts
+++ b/web/src/app/models/submission/result.model.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/models/submission/submission.model.ts
+++ b/web/src/app/models/submission/submission.model.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/models/survey.model.ts
+++ b/web/src/app/models/survey.model.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/models/task/multiple-choice.model.ts
+++ b/web/src/app/models/task/multiple-choice.model.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/models/task/option.model.ts
+++ b/web/src/app/models/task/option.model.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/models/task/task.model.ts
+++ b/web/src/app/models/task/task.model.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/models/user.model.ts
+++ b/web/src/app/models/user.model.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/create-survey.component.html
+++ b/web/src/app/pages/create-survey/create-survey.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2023 Google LLC
+  Copyright 2023 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/create-survey.component.scss
+++ b/web/src/app/pages/create-survey/create-survey.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/create-survey.component.spec.ts
+++ b/web/src/app/pages/create-survey/create-survey.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/create-survey.component.ts
+++ b/web/src/app/pages/create-survey/create-survey.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/create-survey.module.ts
+++ b/web/src/app/pages/create-survey/create-survey.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/job-details/job-details.component.html
+++ b/web/src/app/pages/create-survey/job-details/job-details.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2023 Google LLC
+  Copyright 2023 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/job-details/job-details.component.scss
+++ b/web/src/app/pages/create-survey/job-details/job-details.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/job-details/job-details.component.spec.ts
+++ b/web/src/app/pages/create-survey/job-details/job-details.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/job-details/job-details.component.ts
+++ b/web/src/app/pages/create-survey/job-details/job-details.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/job-details/job-details.module.ts
+++ b/web/src/app/pages/create-survey/job-details/job-details.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/loi-permissions/loi-permissions.component.html
+++ b/web/src/app/pages/create-survey/loi-permissions/loi-permissions.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2023 Google LLC
+  Copyright 2023 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/loi-permissions/loi-permissions.component.scss
+++ b/web/src/app/pages/create-survey/loi-permissions/loi-permissions.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/loi-permissions/loi-permissions.component.spec.ts
+++ b/web/src/app/pages/create-survey/loi-permissions/loi-permissions.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/loi-permissions/loi-permissions.component.ts
+++ b/web/src/app/pages/create-survey/loi-permissions/loi-permissions.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/loi-permissions/loi-permissions.module.ts
+++ b/web/src/app/pages/create-survey/loi-permissions/loi-permissions.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/loi-selection/loi-selection.component.html
+++ b/web/src/app/pages/create-survey/loi-selection/loi-selection.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2023 Google LLC
+  Copyright 2023 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/loi-selection/loi-selection.component.scss
+++ b/web/src/app/pages/create-survey/loi-selection/loi-selection.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/loi-selection/loi-selection.component.spec.ts
+++ b/web/src/app/pages/create-survey/loi-selection/loi-selection.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/loi-selection/loi-selection.component.ts
+++ b/web/src/app/pages/create-survey/loi-selection/loi-selection.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/loi-selection/loi-selection.module.ts
+++ b/web/src/app/pages/create-survey/loi-selection/loi-selection.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/survey-details/survey-details.component.html
+++ b/web/src/app/pages/create-survey/survey-details/survey-details.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2023 Google LLC
+  Copyright 2023 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/survey-details/survey-details.component.scss
+++ b/web/src/app/pages/create-survey/survey-details/survey-details.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/survey-details/survey-details.component.spec.ts
+++ b/web/src/app/pages/create-survey/survey-details/survey-details.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/survey-details/survey-details.component.ts
+++ b/web/src/app/pages/create-survey/survey-details/survey-details.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/survey-details/survey-details.module.ts
+++ b/web/src/app/pages/create-survey/survey-details/survey-details.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/task-details/add-task-button/add-task-button.component.html
+++ b/web/src/app/pages/create-survey/task-details/add-task-button/add-task-button.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2023 Google LLC
+  Copyright 2023 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/task-details/add-task-button/add-task-button.component.scss
+++ b/web/src/app/pages/create-survey/task-details/add-task-button/add-task-button.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/task-details/add-task-button/add-task-button.component.spec.ts
+++ b/web/src/app/pages/create-survey/task-details/add-task-button/add-task-button.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/task-details/add-task-button/add-task-button.component.ts
+++ b/web/src/app/pages/create-survey/task-details/add-task-button/add-task-button.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/task-details/add-task-button/add-task-button.module.ts
+++ b/web/src/app/pages/create-survey/task-details/add-task-button/add-task-button.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/task-details/task-details.component.html
+++ b/web/src/app/pages/create-survey/task-details/task-details.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2023 Google LLC
+  Copyright 2023 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/task-details/task-details.component.scss
+++ b/web/src/app/pages/create-survey/task-details/task-details.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/task-details/task-details.component.spec.ts
+++ b/web/src/app/pages/create-survey/task-details/task-details.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/task-details/task-details.component.ts
+++ b/web/src/app/pages/create-survey/task-details/task-details.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/task-details/task-details.module.ts
+++ b/web/src/app/pages/create-survey/task-details/task-details.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/task-details/task-input/task-input.component.html
+++ b/web/src/app/pages/create-survey/task-details/task-input/task-input.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2023 Google LLC
+  Copyright 2023 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/task-details/task-input/task-input.component.scss
+++ b/web/src/app/pages/create-survey/task-details/task-input/task-input.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/task-details/task-input/task-input.component.spec.ts
+++ b/web/src/app/pages/create-survey/task-details/task-input/task-input.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/task-details/task-input/task-input.component.ts
+++ b/web/src/app/pages/create-survey/task-details/task-input/task-input.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/create-survey/task-details/task-input/task-input.module.ts
+++ b/web/src/app/pages/create-survey/task-details/task-input/task-input.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/edit-survey/edit-job/edit-job.component.spec.ts
+++ b/web/src/app/pages/edit-survey/edit-job/edit-job.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/edit-survey/edit-job/edit-job.component.ts
+++ b/web/src/app/pages/edit-survey/edit-job/edit-job.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/edit-survey/edit-job/edit-job.module.ts
+++ b/web/src/app/pages/edit-survey/edit-job/edit-job.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/edit-survey/edit-survey.component.html
+++ b/web/src/app/pages/edit-survey/edit-survey.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2023 Google LLC
+  Copyright 2023 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/pages/edit-survey/edit-survey.component.scss
+++ b/web/src/app/pages/edit-survey/edit-survey.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/edit-survey/edit-survey.component.spec.ts
+++ b/web/src/app/pages/edit-survey/edit-survey.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/edit-survey/edit-survey.component.ts
+++ b/web/src/app/pages/edit-survey/edit-survey.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/edit-survey/edit-survey.module.ts
+++ b/web/src/app/pages/edit-survey/edit-survey.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/edit-survey/survey-json/survey-json.component.html
+++ b/web/src/app/pages/edit-survey/survey-json/survey-json.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2023 Google LLC
+  Copyright 2023 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/pages/edit-survey/survey-json/survey-json.component.scss
+++ b/web/src/app/pages/edit-survey/survey-json/survey-json.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/edit-survey/survey-json/survey-json.component.ts
+++ b/web/src/app/pages/edit-survey/survey-json/survey-json.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/edit-survey/survey-json/survey-json.module.ts
+++ b/web/src/app/pages/edit-survey/survey-json/survey-json.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/error/error.component.html
+++ b/web/src/app/pages/error/error.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2023 Google LLC
+  Copyright 2023 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/pages/error/error.component.scss
+++ b/web/src/app/pages/error/error.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/error/error.component.ts
+++ b/web/src/app/pages/error/error.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/error/error.module.ts
+++ b/web/src/app/pages/error/error.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page-container.component.css
+++ b/web/src/app/pages/main-page-container/main-page-container.component.css
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page-container.component.html
+++ b/web/src/app/pages/main-page-container/main-page-container.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2020 Google LLC
+  Copyright 2020 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page-container.component.spec.ts
+++ b/web/src/app/pages/main-page-container/main-page-container.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page-container.component.ts
+++ b/web/src/app/pages/main-page-container/main-page-container.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page-container.module.ts
+++ b/web/src/app/pages/main-page-container/main-page-container.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/drawing-tools/drawing-tools.component.html
+++ b/web/src/app/pages/main-page-container/main-page/drawing-tools/drawing-tools.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2020 Google LLC
+  Copyright 2020 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/drawing-tools/drawing-tools.component.scss
+++ b/web/src/app/pages/main-page-container/main-page/drawing-tools/drawing-tools.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/drawing-tools/drawing-tools.component.spec.ts
+++ b/web/src/app/pages/main-page-container/main-page/drawing-tools/drawing-tools.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2021 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/drawing-tools/drawing-tools.component.ts
+++ b/web/src/app/pages/main-page-container/main-page/drawing-tools/drawing-tools.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/drawing-tools/drawing-tools.module.ts
+++ b/web/src/app/pages/main-page-container/main-page/drawing-tools/drawing-tools.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/job-dialog/edit-style-button/color-picker/color-picker.component.html
+++ b/web/src/app/pages/main-page-container/main-page/job-dialog/edit-style-button/color-picker/color-picker.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2020 Google LLC
+  Copyright 2020 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/job-dialog/edit-style-button/color-picker/color-picker.component.scss
+++ b/web/src/app/pages/main-page-container/main-page/job-dialog/edit-style-button/color-picker/color-picker.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/job-dialog/edit-style-button/color-picker/color-picker.component.spec.ts
+++ b/web/src/app/pages/main-page-container/main-page/job-dialog/edit-style-button/color-picker/color-picker.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/job-dialog/edit-style-button/color-picker/color-picker.component.ts
+++ b/web/src/app/pages/main-page-container/main-page/job-dialog/edit-style-button/color-picker/color-picker.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/job-dialog/edit-style-button/color-picker/color-picker.module.ts
+++ b/web/src/app/pages/main-page-container/main-page/job-dialog/edit-style-button/color-picker/color-picker.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/job-dialog/edit-style-button/edit-style-button.component.html
+++ b/web/src/app/pages/main-page-container/main-page/job-dialog/edit-style-button/edit-style-button.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2020 Google LLC
+  Copyright 2020 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/job-dialog/edit-style-button/edit-style-button.component.spec.ts
+++ b/web/src/app/pages/main-page-container/main-page/job-dialog/edit-style-button/edit-style-button.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/job-dialog/edit-style-button/edit-style-button.component.ts
+++ b/web/src/app/pages/main-page-container/main-page/job-dialog/edit-style-button/edit-style-button.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/job-dialog/edit-style-button/edit-style-button.module.ts
+++ b/web/src/app/pages/main-page-container/main-page/job-dialog/edit-style-button/edit-style-button.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/job-dialog/job-dialog.component.html
+++ b/web/src/app/pages/main-page-container/main-page/job-dialog/job-dialog.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2019 Google LLC
+  Copyright 2019 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/job-dialog/job-dialog.component.scss
+++ b/web/src/app/pages/main-page-container/main-page/job-dialog/job-dialog.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/job-dialog/job-dialog.component.spec.ts
+++ b/web/src/app/pages/main-page-container/main-page/job-dialog/job-dialog.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/job-dialog/job-dialog.component.ts
+++ b/web/src/app/pages/main-page-container/main-page/job-dialog/job-dialog.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/job-dialog/job-dialog.module.ts
+++ b/web/src/app/pages/main-page-container/main-page/job-dialog/job-dialog.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/job-dialog/task-editor/option-editor/option-editor.component.html
+++ b/web/src/app/pages/main-page-container/main-page/job-dialog/task-editor/option-editor/option-editor.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2020 Google LLC
+  Copyright 2020 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/job-dialog/task-editor/option-editor/option-editor.component.scss
+++ b/web/src/app/pages/main-page-container/main-page/job-dialog/task-editor/option-editor/option-editor.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/job-dialog/task-editor/option-editor/option-editor.component.spec.ts
+++ b/web/src/app/pages/main-page-container/main-page/job-dialog/task-editor/option-editor/option-editor.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/job-dialog/task-editor/option-editor/option-editor.component.ts
+++ b/web/src/app/pages/main-page-container/main-page/job-dialog/task-editor/option-editor/option-editor.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/job-dialog/task-editor/option-editor/option-editor.module.ts
+++ b/web/src/app/pages/main-page-container/main-page/job-dialog/task-editor/option-editor/option-editor.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/job-dialog/task-editor/task-editor.component.html
+++ b/web/src/app/pages/main-page-container/main-page/job-dialog/task-editor/task-editor.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2020 Google LLC
+  Copyright 2020 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/job-dialog/task-editor/task-editor.component.scss
+++ b/web/src/app/pages/main-page-container/main-page/job-dialog/task-editor/task-editor.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/job-dialog/task-editor/task-editor.component.spec.ts
+++ b/web/src/app/pages/main-page-container/main-page/job-dialog/task-editor/task-editor.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/job-dialog/task-editor/task-editor.component.ts
+++ b/web/src/app/pages/main-page-container/main-page/job-dialog/task-editor/task-editor.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/job-dialog/task-editor/task-editor.module.ts
+++ b/web/src/app/pages/main-page-container/main-page/job-dialog/task-editor/task-editor.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/main-page.component.html
+++ b/web/src/app/pages/main-page-container/main-page/main-page.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2019 Google LLC
+  Copyright 2019 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/main-page.component.scss
+++ b/web/src/app/pages/main-page-container/main-page/main-page.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/main-page.component.spec.ts
+++ b/web/src/app/pages/main-page-container/main-page/main-page.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/main-page.component.ts
+++ b/web/src/app/pages/main-page-container/main-page/main-page.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/main-page.module.ts
+++ b/web/src/app/pages/main-page-container/main-page/main-page.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/map/map.component.html
+++ b/web/src/app/pages/main-page-container/main-page/map/map.component.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2019 Google LLC
+Copyright 2019 The Ground Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/map/map.component.scss
+++ b/web/src/app/pages/main-page-container/main-page/map/map.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/map/map.component.spec.ts
+++ b/web/src/app/pages/main-page-container/main-page/map/map.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2021 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/map/map.component.ts
+++ b/web/src/app/pages/main-page-container/main-page/map/map.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/map/map.module.ts
+++ b/web/src/app/pages/main-page-container/main-page/map/map.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/map/select-loi-dialog/select-loi-dialog.component.ts
+++ b/web/src/app/pages/main-page-container/main-page/map/select-loi-dialog/select-loi-dialog.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2021 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/map/select-loi-dialog/select-loi-dialog.html
+++ b/web/src/app/pages/main-page-container/main-page/map/select-loi-dialog/select-loi-dialog.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2021 Google LLC
+  Copyright 2021 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/map/select-loi-dialog/select-loi-dialog.module.ts
+++ b/web/src/app/pages/main-page-container/main-page/map/select-loi-dialog/select-loi-dialog.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2021 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/job-list/job-list.component.html
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/job-list/job-list.component.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2020 Google LLC
+Copyright 2020 The Ground Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/job-list/job-list.component.scss
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/job-list/job-list.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/job-list/job-list.component.spec.ts
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/job-list/job-list.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/job-list/job-list.component.ts
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/job-list/job-list.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/job-list/job-list.module.ts
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/job-list/job-list.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/loi-list/loi-list.component.html
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/loi-list/loi-list.component.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2021 Google LLC
+Copyright 2021 The Ground Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/loi-list/loi-list.component.scss
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/loi-list/loi-list.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/loi-list/loi-list.component.spec.ts
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/loi-list/loi-list.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2021 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/loi-list/loi-list.component.ts
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/loi-list/loi-list.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2021 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/loi-list/loi-list.module.ts
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/loi-list/loi-list.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2021 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel-header/loi-panel-header.component.html
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel-header/loi-panel-header.component.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2020 Google LLC
+Copyright 2020 The Ground Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel-header/loi-panel-header.component.scss
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel-header/loi-panel-header.component.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Google LLC
+Copyright 2020 The Ground Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel-header/loi-panel-header.component.spec.ts
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel-header/loi-panel-header.component.spec.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Google LLC
+Copyright 2020 The Ground Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel-header/loi-panel-header.component.ts
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel-header/loi-panel-header.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel-header/loi-panel-header.module.ts
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel-header/loi-panel-header.module.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Google LLC
+Copyright 2020 The Ground Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel.component.html
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel.component.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2020 Google LLC
+Copyright 2020 The Ground Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel.component.scss
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel.component.spec.ts
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel.component.ts
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel.module.ts
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/side-panel.component.css
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/side-panel.component.css
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/side-panel.component.html
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/side-panel.component.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2020 Google LLC
+Copyright 2020 The Ground Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/side-panel.component.ts
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/side-panel.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/side-panel.module.ts
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/side-panel.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/submission-form/submission-form.component.html
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/submission-form/submission-form.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2020 Google LLC
+  Copyright 2020 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/submission-form/submission-form.component.scss
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/submission-form/submission-form.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/submission-form/submission-form.component.spec.ts
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/submission-form/submission-form.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/submission-form/submission-form.component.ts
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/submission-form/submission-form.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/side-panel/submission-form/submission-form.module.ts
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/submission-form/submission-form.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/survey-header/survey-header.component.html
+++ b/web/src/app/pages/main-page-container/main-page/survey-header/survey-header.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2020 Google LLC
+  Copyright 2020 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/survey-header/survey-header.component.scss
+++ b/web/src/app/pages/main-page-container/main-page/survey-header/survey-header.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/survey-header/survey-header.component.spec.ts
+++ b/web/src/app/pages/main-page-container/main-page/survey-header/survey-header.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/survey-header/survey-header.component.ts
+++ b/web/src/app/pages/main-page-container/main-page/survey-header/survey-header.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/survey-header/survey-header.module.ts
+++ b/web/src/app/pages/main-page-container/main-page/survey-header/survey-header.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/title-dialog/title-dialog.component.html
+++ b/web/src/app/pages/main-page-container/main-page/title-dialog/title-dialog.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2020 Google LLC
+  Copyright 2020 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/title-dialog/title-dialog.component.scss
+++ b/web/src/app/pages/main-page-container/main-page/title-dialog/title-dialog.component.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/title-dialog/title-dialog.component.spec.ts
+++ b/web/src/app/pages/main-page-container/main-page/title-dialog/title-dialog.component.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/title-dialog/title-dialog.component.ts
+++ b/web/src/app/pages/main-page-container/main-page/title-dialog/title-dialog.component.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/pages/main-page-container/main-page/title-dialog/title-dialog.module.ts
+++ b/web/src/app/pages/main-page-container/main-page/title-dialog/title-dialog.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/routing.module.ts
+++ b/web/src/app/routing.module.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/auth/auth.guard.ts
+++ b/web/src/app/services/auth/auth.guard.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/auth/auth.service.spec.ts
+++ b/web/src/app/services/auth/auth.service.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/auth/auth.service.ts
+++ b/web/src/app/services/auth/auth.service.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/data-import/data-import.service.spec.ts
+++ b/web/src/app/services/data-import/data-import.service.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/data-import/data-import.service.ts
+++ b/web/src/app/services/data-import/data-import.service.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/data-store/data-store.service.spec.ts
+++ b/web/src/app/services/data-store/data-store.service.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/data-store/data-store.service.ts
+++ b/web/src/app/services/data-store/data-store.service.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/dialog/dialog.service.spec.ts
+++ b/web/src/app/services/dialog/dialog.service.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2021 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/dialog/dialog.service.ts
+++ b/web/src/app/services/dialog/dialog.service.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2021 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/drawing-tools/drawing-tools.service.ts
+++ b/web/src/app/services/drawing-tools/drawing-tools.service.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/ground-pin/ground-pin.service.ts
+++ b/web/src/app/services/ground-pin/ground-pin.service.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/http-client/http-client.service.ts
+++ b/web/src/app/services/http-client/http-client.service.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/job/job.service.spec.ts
+++ b/web/src/app/services/job/job.service.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/job/job.service.ts
+++ b/web/src/app/services/job/job.service.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/loading-state.model.ts
+++ b/web/src/app/services/loading-state.model.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/loi/loi.service.spec.ts
+++ b/web/src/app/services/loi/loi.service.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/loi/loi.service.ts
+++ b/web/src/app/services/loi/loi.service.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/navigation/navigation.service.spec.ts
+++ b/web/src/app/services/navigation/navigation.service.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/navigation/navigation.service.ts
+++ b/web/src/app/services/navigation/navigation.service.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/notification/notification.service.spec.ts
+++ b/web/src/app/services/notification/notification.service.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2021 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/notification/notification.service.ts
+++ b/web/src/app/services/notification/notification.service.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2021 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/submission/submission.service.spec.ts
+++ b/web/src/app/services/submission/submission.service.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/submission/submission.service.ts
+++ b/web/src/app/services/submission/submission.service.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/survey/survey.service.spec.ts
+++ b/web/src/app/services/survey/survey.service.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/survey/survey.service.ts
+++ b/web/src/app/services/survey/survey.service.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/task/task.service.spec.ts
+++ b/web/src/app/services/task/task.service.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/app/services/task/task.service.ts
+++ b/web/src/app/services/task/task.service.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/assets/img/polygon_icon.svg
+++ b/web/src/assets/img/polygon_icon.svg
@@ -1,5 +1,5 @@
 <!--
-Copyright 2021 Google LLC
+Copyright 2021 The Ground Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/web/src/environments/environment.dev.ts
+++ b/web/src/environments/environment.dev.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/environments/environment.local.ts
+++ b/web/src/environments/environment.local.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/environments/environment.prod.ts
+++ b/web/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/environments/environment.test.ts
+++ b/web/src/environments/environment.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2020 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/environments/environment.ts
+++ b/web/src/environments/environment.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/ground-theme.scss
+++ b/web/src/ground-theme.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Google LLC
+ * Copyright 2023 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -1,5 +1,5 @@
 <!--
-Copyright 2019 Google LLC
+Copyright 2019 The Ground Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/polyfills.ts
+++ b/web/src/polyfills.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/test.ts
+++ b/web/src/test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/testing/activated-route-stub.ts
+++ b/web/src/testing/activated-route-stub.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2019 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/testing/helpers.ts
+++ b/web/src/testing/helpers.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/web/src/testing/test-data.ts
+++ b/web/src/testing/test-data.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2021 The Ground Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
As per guidance in Google OSS docs:

* https://opensource.google/documentation/reference/releasing/authors

And "Recommended Citation" in FAO terms and conditions:

* https://www.fao.org/contact-us/terms/en/

Closes #1129

@rfontanarosa PTAL?

@DaoyuT @nwkotto @os-micmec FYI

We considered adding "Project" or "Platform" to the name, but decided against it. From @amegantz:

> I think "The Ground Authors" is enough. "Platform" is a loaded word that probably encompasses more than what we're doing, and imo "Project" makes it seem like a perpetual WIP.

I agree with those sentiments, so leaving as "The Ground Authors."