### PR TITLE
fix(menu): rename "download submissions" to "download job data"

### DIFF
--- a/web/src/app/components/job-list-item/job-list-item.component.html
+++ b/web/src/app/components/job-list-item/job-list-item.component.html
@@ -70,7 +70,7 @@ limitations under the License.
             <a class="download" (click)="onDownloadCsvClick()" target="_blank">
               <button mat-menu-item>
                 <mat-icon>cloud_download</mat-icon>
-                <span>Download submissions</span>
+                <span>Download job data</span>
               </button>
             </a>
           </mat-menu>


### PR DESCRIPTION
close: #1398 