### PR TITLE
Replace loadLocationOfInterest$ with lois$.

### DIFF
--- a/web/src/app/services/data-store/data-store.service.ts
+++ b/web/src/app/services/data-store/data-store.service.ts
@@ -251,37 +251,6 @@ export class DataStoreService {
   }
 
   /**
-   * Returns an Observable that loads and emits the LOI with the specified
-   * uuid.
-   *
-   * @param surveyId the id of the survey in which requested LOI is.
-   * @param loiId the id of the requested LOI.
-   */
-  loadLocationOfInterest$(
-    surveyId: string,
-    loiId: string
-  ): Observable<LocationOfInterest> {
-    return this.db
-      .collection(`${SURVEYS_COLLECTION_NAME}/${surveyId}/lois`)
-      .doc(loiId)
-      .get()
-      .pipe(
-        // Fail with error if LOI could not be loaded.
-        map(doc => {
-          const loi = LoiDataConverter.toLocationOfInterest(
-            doc.id,
-            doc.data()! as DocumentData
-          );
-          if (loi instanceof Error) {
-            throw loi;
-          }
-
-          return loi;
-        })
-      );
-  }
-
-  /**
    * Returns a stream containing the user with the specified id. Remote changes
    * to the user will cause a new value to be emitted.
    *

--- a/web/src/app/services/loi/loi.service.ts
+++ b/web/src/app/services/loi/loi.service.ts
@@ -65,13 +65,10 @@ export class LocationOfInterestService {
 
     this.selectedLocationOfInterest$ = this.selectedLocationOfInterestId$.pipe(
       switchMap(loiId =>
-        surveyService
-          .getActiveSurvey$()
-          .pipe(
-            switchMap(survey =>
-              this.dataStore.loadLocationOfInterest$(survey.id, loiId)
-            )
-          )
+        surveyService.getActiveSurvey$().pipe(
+          switchMap(survey => dataStore.lois$(survey)),
+          map(lois => lois.find(loi => loi.id === loiId)!)
+        )
       )
     );
   }


### PR DESCRIPTION
`lois$` calls `.collection(LOI_COLLECTION_NAME)...` and `loadLocationOfInterest$` calls `.collection(LOI_COLLECTION_NAME).doc(loiId)...`.

For some reason, when `loadLocationOfInterest$` is subscribed, `loi$` emmits a list of LOI of that ID and then a list of full LOIs. That's why it's causing the bug(#1441). We don't have to have `loadLocationOfInterest$` anyway, so here I replaced `loadLocationOfInterest$` with `lois$` plus a `finding LOI by its id from the list` logic.

And now the map fits correctly showing all the LOIs.
![Screenshot 2024-01-16 at 3 30 48 PM](https://github.com/google/ground-platform/assets/10445677/27cc962f-356e-405c-9992-75f28f25390f)
