### PR TITLE
Upgrade to Node.js 18

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -47,7 +47,7 @@
         "wkt": "0.1.1"
       },
       "engines": {
-        "node": "16"
+        "node": "18"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -34,7 +34,7 @@
     "ts-node": "^10.9.1"
   },
   "engines": {
-    "node": "16"
+    "node": "18"
   },
   "private": true,
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "firebase-tools": "11.23.1"
       },
       "engines": {
-        "node": "16"
+        "node": "18"
       }
     },
     "node_modules/firebase-tools": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "firebase-tools": "11.23.1"
   },
   "engines": {
-    "node": "16"
+    "node": "18"
   }
 }


### PR DESCRIPTION
Tested by manually deploying to dev server with local Node.js v18.19.0. Also updated Developers guide to reflect this.