### PR TITLE
Prevent non-passlisted users from accessing user photos

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -48,5 +48,8 @@
   "functions": {
     "source": "functions",
     "ignore": [".git", "firebase-debug.log", "firebase-debug.*.log"]
+  },
+  "storage": {
+    "rules": "storage/storage.rules"
   }
 }

--- a/storage/storage.rules
+++ b/storage/storage.rules
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2024 The Ground Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    /**
+     * Returns email address for the requesting user.
+     */
+    function email() {
+      return request.auth.token.email;
+    }
+
+    /**
+     * Returns the regular expression for users allowed access.
+     */
+    function passRegexp() {
+      return firestore.get(/databases/(default)/documents/passlist/regexp).data.regexp
+    }
+
+    /**
+     * Returns true iff the specified email is in the pass list.
+     */
+    function isInPassList(email) {
+      return firestore.exists(/databases/(default)/documents/passlist/$(email))
+    }
+
+    /**
+     * Returns true iff the user's email is in the implicit regex or
+     * explicit passlist.
+     */
+    function canAccess(email) {
+      return email.matches(passRegexp()) || isInPassList(email);
+    }
+    
+    match /offline-imagery/{allPaths=**} {
+      // All authenticated users can read.
+      allow read: if canAccess(email());
+    }
+  }
+}

--- a/storage/storage.rules
+++ b/storage/storage.rules
@@ -50,5 +50,10 @@ service firebase.storage {
       // All authenticated users can read.
       allow read: if canAccess(email());
     }
+    
+    match /user-media/{allPaths=**} {
+      // All authenticated users can read.
+      allow create, read, write: if canAccess(email());
+    }    
   }
 }


### PR DESCRIPTION
Towards #1373.

Next steps: Check ACLs of corresponding survey and owner of submissions to implement finer grained ACLs.

@os-micmec PTAL?