### PR TITLE
[ACLs] Enforce ACLs on surveys

### DIFF
--- a/firestore/firestore.rules
+++ b/firestore/firestore.rules
@@ -23,7 +23,7 @@
     }
 
     /**
-     * Returns email address for the requesting user.
+     * Returns the email address of the requesting user.
      */
     function getEmail() {
       return request.auth.token.email;
@@ -37,15 +37,15 @@
     }
 
     /**
-     * Returns the regular expression for users allowed access.
+     * Returns the regular expression matching emails granted access.
      */
     function getPassRegexp() {
       return get(/databases/$(database)/documents/passlist/regexp).data.regexp
     }
 
     /**
-     * Returns true iff the user's email is in the implicit regex or
-     * explicit passlist.
+     * Returns true iff the user's email matches the passlist regex or
+     * is explicitly listed in the passlist.
      */
     function inPasslist(email) {
       return email.matches(getPassRegexp()) || exists(/databases/$(database)/documents/passlist/$(email));
@@ -60,7 +60,7 @@
     }
 
     /**
-     * Returns true iff the suer with the given email has one of the specified
+     * Returns true iff the user with the given email has one of the specified
      * roles in the given survey.
      */
     function isOneOf(survey, email, roles) {
@@ -69,7 +69,7 @@
 
     /**
      * Returns true iff the user with the given email can manage the specified
-     * survey (i.e., modify the survey document).
+     * survey (modify the survey document, edit user data, etc.).
      */
     function canManageSurvey(survey, email) {
       return inPasslist(email) && isOneOf(survey, email, ['OWNER', 'SURVEY_ORGANIZER']);

--- a/firestore/firestore.rules
+++ b/firestore/firestore.rules
@@ -17,48 +17,38 @@
  // Define access rules for Firestore collections and documents.
  service cloud.firestore {
   match /databases/{database}/documents {
-    /**
-     * Reads access control list for specified surveyId. The ACL is represented
-     * as a map keyed by email, with a single role as the value.
-     */
-    function acl(surveyId) {
-      return get(/databases/$(database)/documents/surveys/$(surveyId)).data.acl;
+
+    function getSurvey(surveyId) {
+      return get(/databases/$(database)/documents/surveys/$(surveyId)).data;
     }
 
     /**
      * Returns email address for the requesting user.
      */
-    function email() {
+    function getEmail() {
       return request.auth.token.email;
     }
 
-    /**
+   /**
      * Returns the role of the specified email address in the given survey.
      */
-    function role(surveyId, email) {
-      return acl(surveyId)[email];
+    function getRole(survey, email) {
+      return survey.acl[email];
     }
 
     /**
      * Returns the regular expression for users allowed access.
      */
-    function passRegexp() {
+    function getPassRegexp() {
       return get(/databases/$(database)/documents/passlist/regexp).data.regexp
-    }
-
-    /**
-     * Returns true iff the specified email is in the pass list.
-     */
-    function isInPassList(email) {
-      return exists(/databases/$(database)/documents/passlist/$(email))
     }
 
     /**
      * Returns true iff the user's email is in the implicit regex or
      * explicit passlist.
      */
-    function canAccess(email) {
-      return email.matches(passRegexp()) || isInPassList(email);
+    function inPasslist(email) {
+      return email.matches(getPassRegexp()) || exists(/databases/$(database)/documents/passlist/$(email));
     }
 
     /**
@@ -66,15 +56,23 @@
      * survey.
      */
     function canViewSurvey(surveyId, email) {
-      return canAccess(email) && role(surveyId, email) != null;
+      return inPasslist(email) && getRole(surveyId, email) != null;
+    }
+
+    /**
+     * Returns true iff the suer with the given email has one of the specified
+     * roles in the given survey.
+     */
+    function isOneOf(survey, email, roles) {
+      return survey.acl[email] in roles;
     }
 
     /**
      * Returns true iff the user with the given email can manage the specified
      * survey (i.e., modify the survey document).
      */
-    function canManageSurvey(surveyId, email) {
-      return canAccess(email) && role(surveyId, email) in ['OWNER', 'SURVEY_ORGANIZER'];
+    function canManageSurvey(survey, email) {
+      return inPasslist(email) && isOneOf(survey, email, ['OWNER', 'SURVEY_ORGANIZER']);
     }
 
     /**
@@ -82,8 +80,8 @@
      * and submissions to the specified survey (i.e., add/edit LOIs and
      * submissions).
      */
-    function canContributeToSurvey(surveyId, email) {
-      return canAccess(email) && role(surveyId, email) in ['OWNER', 'SURVEY_ORGANIZER', 'DATA_COLLECTOR'];
+    function canCollectData(survey, email) {
+      return inPasslist(email) && isOneOf(surveyId, email, ['OWNER', 'SURVEY_ORGANIZER', 'DATA_COLLECTOR']);
     }
 
     /**
@@ -106,28 +104,28 @@
 
     // Apply survey-level ACLs and passlist to survey documents.
     match /surveys/{surveyId} {
-      allow read: if canViewSurvey(surveyId, email());
-      allow read, write: if canManageSurvey(surveyId, email());
-      allow create, read, write: if canAccess(email());
+      allow read: if canViewSurvey(resource.data, getEmail());
+      allow write: if canManageSurvey(resource.data, getEmail());
+      allow create: if inPasslist(getEmail());
     }
 
     // Allow passlisted users to access Terms of Service and other config.
     match /config/{id} {
-      allow read: if canAccess(email());
+      allow read: if inPasslist(getEmail());
     }
 
     // Apply survey-level ACLs and passlist to LOI documents.
     match /surveys/{surveyId}/lois/{loiId} {
-      allow read: if canViewSurvey(surveyId, email());
-      allow create: if canManageSurvey(surveyId, email()) || isOwner(request.resource, email());
-      allow write: if canManageSurvey(surveyId, email()) || isOwner(resource, email());
+      allow read: if canViewSurvey(getSurvey(surveyId), getEmail());
+      allow create: if canManageSurvey(getSurvey(surveyId), getEmail()) || isOwner(request.resource, getEmail());
+      allow write: if canManageSurvey(getSurvey(surveyId), getEmail()) || isOwner(resource, getEmail());
     }
 
     // Apply survey-level ACLs and passlist to submission documents.
     match /surveys/{surveyId}/submissions/{submissionId} {
-      allow read: if canViewSurvey(surveyId, email());
-      allow create: if canManageSurvey(surveyId, email()) || isOwner(request.resource, email());
-      allow write: if canManageSurvey(surveyId, email()) || isOwner(resource, email());
+      allow read: if canViewSurvey(getSurvey(surveyId), getEmail());
+      allow create: if canManageSurvey(getSurvey(surveyId), getEmail()) || isOwner(request.resource, getEmail());
+      allow write: if canManageSurvey(getSurvey(surveyId), getEmail()) || isOwner(resource, getEmail());
     }
   }
 }


### PR DESCRIPTION
Uses the current `resource` to read the survey rather than triggering another read, which would cause rules to fail.

Fixes #1597
Towards #753 

Also cleans up and refactors function names.