### PR TITLE
Fix error where enter key triggers delete in 'select one' or 'select multiple'

### DIFF
--- a/web/src/app/components/tasks-editor/task-form/edit-option/edit-option.component.html
+++ b/web/src/app/components/tasks-editor/task-form/edit-option/edit-option.component.html
@@ -41,10 +41,10 @@
   <div class="delete-button-container">
     <button
       *ngIf="index"
-      tabindex="-1"
       mat-icon-button
       (click)="onDeleteOption(index)"
       matTooltip="Delete Option"
+      type="button"
     >
       <mat-icon>close</mat-icon>
     </button>


### PR DESCRIPTION
Fixes #1625

Buttons by default within `<form>` elements get automatically treated as the submit button
