### PR TITLE
Set width for mat-selects to be the longest option instead of the trigger width

### DIFF
--- a/web/src/app/components/tasks-editor/task-form/task-form.component.html
+++ b/web/src/app/components/tasks-editor/task-form/task-form.component.html
@@ -19,7 +19,11 @@
 
   <div class="task-toolbar">
     <div *ngIf="GeometryTasks.includes(taskGroup)">
-      <mat-select [(value)]="taskGroup" (selectionChange)="onTaskGroupSelect($event.value)">
+      <mat-select
+        [(value)]="taskGroup"
+        [hideSingleSelectionIndicator]="true"
+        (selectionChange)="onTaskGroupSelect($event.value)"
+      >
         <mat-select-trigger class="task-label">
           <mat-icon class="material-symbols-outlined">{{ Tasks[taskGroup].icon }}</mat-icon>
           <div>{{ Tasks[taskGroup].label }}</div>

--- a/web/src/ground-theme.scss
+++ b/web/src/ground-theme.scss
@@ -163,11 +163,14 @@ snack-bar-container.notification {
   width: 1024px;
 }
 
-// TODO: Can remove once upgraded past v16.1, there is a panelWidth
+// TODO(#1633): Can remove once upgraded past v16.1, there is a panelWidth
 // input property for mat-select that can be set to null. By default
 // options are set to the select trigger width, but can be set to the
 // longest option width instead.
-// For context: https://github.com/angular/components/issues/26000
 .cdk-overlay-pane:has(.mat-mdc-select-panel) {
   min-width: fit-content;
+}
+
+.mat-mdc-select-arrow-wrapper{
+  padding-left: 12px;
 }

--- a/web/src/ground-theme.scss
+++ b/web/src/ground-theme.scss
@@ -162,3 +162,12 @@ snack-bar-container.notification {
   margin: 24px;
   width: 1024px;
 }
+
+// TODO: Can remove once upgraded past v16.1, there is a panelWidth
+// input property for mat-select that can be set to null. By default
+// options are set to the select trigger width, but can be set to the
+// longest option width instead.
+// For context: https://github.com/angular/components/issues/26000
+.cdk-overlay-pane:has(.mat-mdc-select-panel) {
+  min-width: fit-content;
+}


### PR DESCRIPTION
Fixes #1623

[cast (3).webm](https://github.com/google/ground-platform/assets/8575252/cc62254b-700a-45e3-95dc-9b7e3ab63d66)
