### PR TITLE
 drawing-tools.component.spec DOM text reinterpreted as HTML

### DIFF
--- a/web/src/app/pages/main-page-container/main-page/drawing-tools/drawing-tools.component.spec.ts
+++ b/web/src/app/pages/main-page-container/main-page/drawing-tools/drawing-tools.component.spec.ts
@@ -255,7 +255,7 @@ describe('DrawingToolsComponent', () => {
       const jobSelectorLabel = fixture.debugElement.query(
         By.css('#job-selector-label')
       ).nativeElement;
-      expect(jobSelectorLabel.innerHTML).toEqual('Adding point for');
+      expect(jobSelectorLabel.innerText).toEqual('Adding point for');
     }));
 
     it('selects first job id by default', () => {


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML. Always be cautious when dealing with user input or dynamic content to prevent security risks.