### PR TITLE
 edit-survey.component.spec.ts DOM text reinterpreted as HTML 

### DIFF
--- a/web/src/app/pages/edit-survey/edit-survey.component.spec.ts
+++ b/web/src/app/pages/edit-survey/edit-survey.component.spec.ts
@@ -157,7 +157,7 @@ describe('EditSurveyComponent', () => {
     const spinner = fixture.debugElement.query(By.css('#loading-spinner'))
       .nativeElement as HTMLElement;
     // TODO(#1170): Extract the spinner into a component
-    expect(spinner.innerHTML).toContain('Loading survey...');
+    expect(spinner.innerText).toContain('Loading survey...');
   });
 
   describe('when routed in with survey ID', () => {


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML. Always be cautious when dealing with user input or dynamic content to prevent security risks.