### PR TITLE
Revert Maps dep updates

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -43,12 +43,13 @@
         "@angular/compiler-cli": "^17.3.8",
         "@angular/language-service": "^17.3.8",
         "@jridgewell/source-map": "^0.3.2",
-        "@types/google.maps": "^3.55.8",
+        "@types/googlemaps": "^3.43.3",
         "@types/jasmine": "~3.6.0",
         "@types/jasmine-expect": "3.8.1",
         "@types/jasminewd2": "^2.0.8",
         "@types/node": "^14.11.2",
         "@types/webpack-env": "^1.15.3",
+        "eslint": "^8.26.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-import": "^2.29.0",
@@ -7194,6 +7195,13 @@
       "version": "3.55.8",
       "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.55.8.tgz",
       "integrity": "sha512-aSyvlCRXzF9Jtjqq4zmA24sczKZ0QWJnn4zRrkufCoohHulS6LCf4KsF22eAlnHBuVYwEhQoMXIufUS7kXF5uA=="
+    },
+    "node_modules/@types/googlemaps": {
+      "version": "3.43.3",
+      "resolved": "https://registry.npmjs.org/@types/googlemaps/-/googlemaps-3.43.3.tgz",
+      "integrity": "sha512-ZWNoz/O8MPEpiajvj7QiqCY8tTLFNqNZ/a+s+zTV58wFVNAvvqV4bdGfnsjTb5Cs4V6wEsLrX8XRhmnyYJ2Tdg==",
+      "deprecated": "Types for the Google Maps browser API have moved to @types/google.maps. Note: these types are not for the googlemaps npm package, which is a Node API.",
+      "dev": true
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
@@ -29478,6 +29486,12 @@
       "version": "3.55.8",
       "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.55.8.tgz",
       "integrity": "sha512-aSyvlCRXzF9Jtjqq4zmA24sczKZ0QWJnn4zRrkufCoohHulS6LCf4KsF22eAlnHBuVYwEhQoMXIufUS7kXF5uA=="
+    },
+    "@types/googlemaps": {
+      "version": "3.43.3",
+      "resolved": "https://registry.npmjs.org/@types/googlemaps/-/googlemaps-3.43.3.tgz",
+      "integrity": "sha512-ZWNoz/O8MPEpiajvj7QiqCY8tTLFNqNZ/a+s+zTV58wFVNAvvqV4bdGfnsjTb5Cs4V6wEsLrX8XRhmnyYJ2Tdg==",
+      "dev": true
     },
     "@types/http-errors": {
       "version": "2.0.4",

--- a/web/package.json
+++ b/web/package.json
@@ -58,7 +58,7 @@
     "@angular/compiler-cli": "^17.3.8",
     "@angular/language-service": "^17.3.8",
     "@jridgewell/source-map": "^0.3.2",
-    "@types/google.maps": "^3.55.8",
+    "@types/googlemaps": "^3.43.3",
     "@types/jasmine": "~3.6.0",
     "@types/jasmine-expect": "3.8.1",
     "@types/jasminewd2": "^2.0.8",


### PR DESCRIPTION
Fixes web build breakage from #1806 :

```
Error: error TS2688: Cannot find type definition file for 'googlemaps'.
  The file is in the program because:
    Entry point of type library 'googlemaps' specified in compilerOptions
```

@rfontanarosa PTAL?