### PR TITLE
Fixed wrong compiler options

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -86,7 +86,7 @@
     "karma-jasmine-matchers": "5.0.0",
     "prettier": "^2.8.1",
     "prettier-eslint": "^15.0.1",
-    "puppeteer": "^19.2.0",
+    "puppeteer": "^22.10.0",
     "ts-node": "^8.10.2",
     "typescript": "^5.4.5"
   }

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/app",
-    "types": ["googlemaps", "node"]
+    "types": ["google.maps", "node"]
   },
   "files": ["src/main.ts"],
   "include": ["src/**/*.ts"],


### PR DESCRIPTION
@types/googlemaps has been changed into @types/google.maps ,but the compilerOptions wasn't updated.