### PR TITLE
Clean up proto defs

### DIFF
--- a/proto/src/google/ground/v1beta1/geometry.proto
+++ b/proto/src/google/ground/v1beta1/geometry.proto
@@ -29,8 +29,10 @@ message Geometry {
   oneof geometry_type {
     // A point geometry.
     Point point = 1;
+
     // A polygon geometry.
     Polygon polygon = 2;
+    
     // A multi-polygon geometry.
     MultiPolygon multi_polygon = 3;
   }
@@ -40,6 +42,7 @@ message Geometry {
 message Coordinates {
   // Required. WGS 84 latitude.
   double latitude = 1;
+
   // Required. WGS 84 longitude.
   double longitude = 2;
 }
@@ -61,6 +64,7 @@ message LinearRing {
 message Polygon {
   // Required. The outer shell of the polygon.
   LinearRing shell = 1;
+
   // Holes in the polygon, if any.
   repeated LinearRing holes = 2;
 }

--- a/proto/src/google/ground/v1beta1/job.proto
+++ b/proto/src/google/ground/v1beta1/job.proto
@@ -16,7 +16,7 @@
 
 syntax = "proto3";
 
-package google.ground.v1beta1;
+package google.ground.v0beta;
 
 option java_multiple_files = true;
 option java_package = "com.google.android.ground.proto";
@@ -26,13 +26,17 @@ option java_package = "com.google.android.ground.proto";
 message Job {
   // Required. The system-defined unique identifier of this entity.
   string id = 1;
+
   // Required. Index of the job when shown in lists.
   int32 index = 2;
+
   // User-facing name of the job.
   string name = 3;
+
   // The style used when rendering geometries and other UI elements associated
   // with this job.
   Style style = 4;
+
   // One or more data collection tasks to be carried out by the user in order
   // to collect and submit data.
   repeated Task tasks = 5;
@@ -49,11 +53,14 @@ message Style {
 message Task {
   // Required. The system-defined unique identifier of this entity.
   string id = 1;
+
   // Index of the task when shown in lists.
   int32 index = 2;
+
   // Question or instructions shown to the user describing the task to be
   // completed.
   string prompt = 3;
+
   // When true, the user may not skip this task.
   bool required = 4;
 
@@ -61,18 +68,21 @@ message Task {
   enum DataCollectionLevel {
     // Default value when level is not specified.
     DATA_COLLECTION_LEVEL_UNSPECIFIED = 0;
+
     // Data collected at this level is used to define a location of
     // interest (LOI). Specifically, geometry tasks of this type may be used
     // to allow data collectors to define the LOI's geometry. Future
     // implementations may use this to allow other LOI properties to be
     // added or modified.
     LOI_METADATA = 1;
+
     // Data collected at this level is associated with, but does not define,
     // a location of interest (LOI). Specifically, geometry tasks of this
     // type define one or more annotations of the associated LOI. rather
     // than the geometry of the LOI itself.
     LOI_DATA = 2;
   }
+
   // Defines to which entity data collected in this task is associated with.
   // Defaults to LOCATION_OF_INTEREST_DATA.
   DataCollectionLevel level = 5;
@@ -86,18 +96,24 @@ message Task {
   oneof task_type {
     // A question whose response is entered manually as text.
     TextQuestion text_question = 7;
+
     // A question whose response is entered manually as a number.
     NumberQuestion number_question = 8;
+
     // A question whose response is entered manually as a date and/or time.
     DateTimeQuestion date_time_question = 9;
+
     // A question whose response is manually selected from a list of
     // options.
     MultipleChoiceQuestion multiple_choice_question = 10;
+
     // A task in which the user must manually draw a geometry (point,
     // polygon, etc.) on the map.
     DrawGeometry draw_geometry = 11;
+
     // A task in which the user must capture their current device location.
     CaptureLocation capture_location = 12;
+
     // A task in which the user must take a photo.
     TakePhoto take_photo = 13;
   }
@@ -136,14 +152,19 @@ message Task {
   message MultipleChoiceQuestion {
     // Valid values for the `type` field.
     enum Type {
+      // Default value when no type is set/
       TYPE_UNSPECIFIED = 0;
+
       // Allow only one valid to be selected.
       SELECT_ONE = 1;
+
       // Allow one or more values to be selected.
       SELECT_MULTIPLE = 2;
     }
+
     // The type of multiple choice question.
     Type type = 1;
+
     // The list of allowed multiple choice options.
     repeated Option options = 2;
 
@@ -156,8 +177,10 @@ message Task {
     message Option {
       // Required. The system-defined unique identifier of this entity.
       string id = 1;
+
       // Required. The index of the option when shown as a list.
       int32 index = 2;
+
       // The user-facing label of the option.
       string label = 3;
     }

--- a/proto/src/google/ground/v1beta1/job.proto
+++ b/proto/src/google/ground/v1beta1/job.proto
@@ -16,7 +16,7 @@
 
 syntax = "proto3";
 
-package google.ground.v0beta;
+package google.ground.v1beta1;
 
 option java_multiple_files = true;
 option java_package = "com.google.android.ground.proto";

--- a/proto/src/google/ground/v1beta1/loi.proto
+++ b/proto/src/google/ground/v1beta1/loi.proto
@@ -56,7 +56,6 @@ message LocationOfInterest {
   // Valid values for `source`.
   enum Source {
     // Indicated the value was not set.
-
     SOURCE_UNSPECIFIED = 0;
 
     // Indicates the LOI was defined by organizers beforehand.
@@ -65,7 +64,6 @@ message LocationOfInterest {
     // Indicated the LOI was added at data collection time.
     DATA_COLLECTOR = 2;
   }
-
   // Required. Indicates who created this LOI.
   Source source = 9;
 

--- a/proto/src/google/ground/v1beta1/loi.proto
+++ b/proto/src/google/ground/v1beta1/loi.proto
@@ -53,8 +53,26 @@ message LocationOfInterest {
   // field in GeoJSON Features.
   string custom_tag = 8;
 
-  // If `true`, the LOI was defined by the survey organizer or generated
-  // by a backend. If `false` or unset, the LOI was added by data collectors
-  // during the data collection process.
-  bool predefined = 9;
+  // Valid values for `source`.
+  enum Source {
+    // Indicated the value was not set.
+    SOURCE_UNSPECIFIED = 0;
+    // Indicates the LOI was defined by organizers beforehand.
+    SURVEY_ORGANIZER = 1;
+    // Indicated the LOI was added at data collection time.
+    DATA_COLLECTOR = 2;
+  }
+  // Required. Indicates who created this LOI.
+  Source source = 9;
+
+  // Arbitrary key-value pairs associated with this LOI.
+  map<string, Property> properties = 10;
+
+  // A single value associated with an LOI.
+  message Property {
+    oneof property_type {
+      string string_value = 1;
+      double numeric_value = 2;
+    }
+  }
 }

--- a/proto/src/google/ground/v1beta1/loi.proto
+++ b/proto/src/google/ground/v1beta1/loi.proto
@@ -56,12 +56,16 @@ message LocationOfInterest {
   // Valid values for `source`.
   enum Source {
     // Indicated the value was not set.
+
     SOURCE_UNSPECIFIED = 0;
+
     // Indicates the LOI was defined by organizers beforehand.
     SURVEY_ORGANIZER = 1;
+
     // Indicated the LOI was added at data collection time.
     DATA_COLLECTOR = 2;
   }
+
   // Required. Indicates who created this LOI.
   Source source = 9;
 
@@ -71,7 +75,10 @@ message LocationOfInterest {
   // A single value associated with an LOI.
   message Property {
     oneof property_type {
+      // A string value.
       string string_value = 1;
+
+      // A numeric value.
       double numeric_value = 2;
     }
   }

--- a/proto/src/google/ground/v1beta1/loi.proto
+++ b/proto/src/google/ground/v1beta1/loi.proto
@@ -53,15 +53,16 @@ message LocationOfInterest {
   // field in GeoJSON Features.
   string custom_tag = 8;
 
-  // Valid values for `source`.
+  // Valid values for location of interest `source`.
   enum Source {
-    // Indicated the value was not set.
+    // Indicates the value was not set.
     SOURCE_UNSPECIFIED = 0;
 
-    // Indicates the LOI was defined by organizers beforehand.
+    // Indicates the LOI was defined in advance by survey organizers, for
+    // example, as part of a statistical sampling design or generated alert.
     SURVEY_ORGANIZER = 1;
 
-    // Indicated the LOI was added at data collection time.
+    // Indicates the LOI was added at data collection time.
     DATA_COLLECTOR = 2;
   }
   // Required. Indicates who created this LOI.

--- a/proto/src/google/ground/v1beta1/loi.proto
+++ b/proto/src/google/ground/v1beta1/loi.proto
@@ -58,14 +58,14 @@ message LocationOfInterest {
     // Indicates the value was not set.
     SOURCE_UNSPECIFIED = 0;
 
-    // Indicates the LOI was defined in advance by survey organizers, for
-    // example, as part of a statistical sampling design or generated alert.
-    SURVEY_ORGANIZER = 1;
+    // Indicates the LOI was imported by survey as part of a
+    // statistical sampling design or other structured source.
+    IMPORTED = 1;
 
     // Indicates the LOI was added at data collection time.
-    DATA_COLLECTOR = 2;
+    FIELD_DATA = 2;
   }
-  // Required. Indicates who created this LOI.
+  // Required. Indicates who created this LOI and when.
   Source source = 9;
 
   // Arbitrary key-value pairs associated with this LOI.

--- a/proto/src/google/ground/v1beta1/submission.proto
+++ b/proto/src/google/ground/v1beta1/submission.proto
@@ -66,17 +66,23 @@ message TaskData {
   oneof task_data_type {
     // A manually entered text response.
     Text text = 4;
+
     // A manually entered number response.
     Number number = 5;
+
     // A manually selected date and/or time response.
     DateTime date_time = 6;
+
     // Response to a multiple-choice question.
     MultipleChoice multiple_choice_question = 7;
+
     // Result of data collector drawing a geometry (e.g., dropping a pin,
     // drawing or walking a perimeter).
     DrawGeometry draw_geometry = 8;
+
     // The result of capturing the device's current fused location.
     CaptureLocation capture_location = 9;
+
     // The result of a "take a photo" task.
     TakePhoto take_photo = 10;
   }
@@ -104,6 +110,7 @@ message TaskData {
   message MultipleChoice {
     // The unique IDs of options selected by the user.
     repeated string selected_option_ids = 1;
+
     // The text provided in the "Other (please specify)" field, if present.
     string other_text = 2;
   }
@@ -118,10 +125,13 @@ message TaskData {
   message CaptureLocation {
     // Required. The device's coordinates.
     Coordinates coordinates = 1;
+
     // The accuracy of `coordinates` returned by the device, in meters.
     double accuracy = 2;
+
     // The altitude captured by the device.
     double altitude = 3;
+
     // Required. The time reported by the device when the location was
     // captured.
     .google.protobuf.Timestamp timestamp = 4;

--- a/proto/src/google/ground/v1beta1/submission.proto
+++ b/proto/src/google/ground/v1beta1/submission.proto
@@ -65,49 +65,49 @@ message TaskData {
   // User-provided data must be one of the following types:
   oneof task_data_type {
     // A manually entered text response.
-    Text text = 4;
+    TextResponse text_response = 4;
 
     // A manually entered number response.
-    Number number = 5;
+    NumberResponse number_response = 5;
 
     // A manually selected date and/or time response.
-    DateTime date_time = 6;
+    DateTimeResponse date_time_response = 6;
 
     // Response to a multiple-choice question.
-    MultipleChoice multiple_choice_question = 7;
+    MultipleChoiceResponses multiple_choice_responses = 7;
 
     // Result of data collector drawing a geometry (e.g., dropping a pin,
     // drawing or walking a perimeter).
-    DrawGeometry draw_geometry = 8;
+    DrawGeometryResult draw_geometry_result = 8;
 
     // The result of capturing the device's current fused location.
-    CaptureLocation capture_location = 9;
+    CaptureLocationResult capture_location_result = 9;
 
     // The result of a "take a photo" task.
-    TakePhoto take_photo = 10;
+    TakePhotoResult take_photo_result = 10;
   }
 
   // A manually entered text response.
-  message Text {
+  message TextResponse {
     // The text provided by the user.
     string text = 1;
   }
 
   // A manually entered number response.
-  message Number {
+  message NumberResponse {
     // The number provided by the user.
     double number = 2;
   }
 
   // A manually selected date and/or time response.
-  message DateTime {
+  message DateTimeResponse {
     // The date and/or time provided by the user. Date is set to
     // UNIX epoch if unspecified (1970-01-01:00Z), time is set to
     // 0:00:00.00.
     .google.protobuf.Timestamp date_time = 1;
   }
 
-  message MultipleChoice {
+  message MultipleChoiceResponses {
     // The unique IDs of options selected by the user.
     repeated string selected_option_ids = 1;
 
@@ -115,14 +115,14 @@ message TaskData {
     string other_text = 2;
   }
 
-  message DrawGeometry {
+  message DrawGeometryResult {
     // The geometry provided by the data collector.
     Geometry geometry = 1;
   }
 
   // The values returned by the data collector's device when completing a
   // "capture location" task.
-  message CaptureLocation {
+  message CaptureLocationResult {
     // Required. The device's coordinates.
     Coordinates coordinates = 1;
 
@@ -138,7 +138,7 @@ message TaskData {
   }
 
   // The result of a "take a photo" task.
-  message TakePhoto {
+  message TakePhotoResult {
     // Relative path of photo in remote storage.
     string photo_path = 1;
   }

--- a/proto/src/google/ground/v1beta1/survey.proto
+++ b/proto/src/google/ground/v1beta1/survey.proto
@@ -25,10 +25,13 @@ option java_package = "com.google.android.ground.proto";
 message Survey {
   // Required. The system-defined unique identifier of this entity.
   string id = 1;
+
   // User-facing name of the survey.
   string name = 2;
+
   // User-facing description of the survey.
   string description = 3;
+
   // Defines who has access to do what with this survey.
   map<string, Role> acl = 4;
 }
@@ -37,10 +40,13 @@ message Survey {
 enum Role {
   // Default value when role is missing.
   ROLE_UNSPECIFIED = 0;
+
   // User may access survey in read-only model.
   VIEWER = 1;
+
   // User may also submit data, but not modify jobs or other survey metadata.
   DATA_COLLECTOR = 2;
+
   // User may also manage the survey, update locations of interest, etc.
   SURVEY_ORGANIZER = 3;
 }


### PR DESCRIPTION
- [x] Replaced `predefined` with `Source` enum
- [x] Renames `TaskData` fields and messages for consistency with those in `Task`
- [x] Adds some whitespace for readability.

@sufyanAbbasi PTAL?

Note I'm still on the fence as to whether to replace remaining `bool` fields with enums, since they will be sparsely used, `false` by default, and are unlikely to ever hold any other values besides `true`:

![image](https://github.com/google/ground-platform/assets/228050/cbc37160-9f33-49c4-a00b-d1dac66ec71e)