### PR TITLE
Add color diff to jasmine test matchers

### DIFF
--- a/functions/jasmine.json
+++ b/functions/jasmine.json
@@ -4,7 +4,8 @@
       "**/*.spec.js"
     ],
     "helpers": [
-      "../../lib/dist/testing/reporter.js"
+      "../../lib/dist/testing/reporter.js",
+      "../../lib/dist/testing/diff.js"
     ],
     "stopSpecOnExpectationFailure": false,
     "random": false

--- a/lib/jasmine.json
+++ b/lib/jasmine.json
@@ -4,7 +4,8 @@
       "**/*.spec.js"
     ],
     "helpers": [
-      "testing/reporter.js"
+      "testing/reporter.js",
+      "testing/diff.js"
     ],
     "stopSpecOnExpectationFailure": false,
     "random": false

--- a/lib/package.json
+++ b/lib/package.json
@@ -33,6 +33,8 @@
     "@types/source-map-support": "^0.5.10",
     "@typescript-eslint/eslint-plugin": "^5.39.0",
     "@typescript-eslint/parser": "^5.39.0",
+    "colors": "^1.4.0",
+    "diff": "^5.2.0",
     "eslint": "^8.26.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.29.1",

--- a/lib/src/testing/diff.js
+++ b/lib/src/testing/diff.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2024 The Ground Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import colors from 'colors/safe';
+import {diffLines} from 'diff';
+
+/**
+ * Decorates a Jasmine matcher with ability to pretty-print differences in
+ * objects.
+ */
+function decorateMatcher(jasmineMatcher) {
+  return (util, customEqualityTesters) => {
+    const matcher = jasmineMatcher(util, customEqualityTesters);
+    return {
+      compare: (actual, expected) => {
+        const result = matcher.compare(actual, expected);
+        if (!result.pass) {
+          const formattedDiffs = formatDiffs(actual, expected);
+          result.message = `${result.message || ''}\n${formattedDiffs}`;
+        }
+        return result;
+      },
+    };
+  };
+}
+
+/**
+ * Formats a diff for display.
+ */
+function formatDiffs(actual, expected) {
+  const diff = diffLines(format(actual), format(expected));
+  return diff.map(formatDiff).join('');
+}
+
+/**
+ * Formats an individual diff for display.
+ *
+ * @param {*} diff The deltas returned by the diff library.
+ * @return {string} Diff line with markers and color codes.
+ */
+function formatDiff(diff) {
+  const {green, red, reset} = colors;
+  const {added, removed, value} = diff;
+  if (added) {
+    return green(`+${value}`);
+  } else if (removed) {
+    return red(`-${value}`);
+  } else {
+    return reset(` ${value}`);
+  }
+}
+
+function format(str) {
+  return JSON.stringify(str, null, 2);
+}
+
+// Apply decorators before running tests.
+beforeAll(() => {
+  jasmine.getEnv().addMatchers({
+    toBe: decorateMatcher(jasmine.matchers.toBe, 'to be'),
+    toEqual: decorateMatcher(jasmine.matchers.toEqual, 'to equal'),
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,6 +96,8 @@
         "@types/source-map-support": "^0.5.10",
         "@typescript-eslint/eslint-plugin": "^5.39.0",
         "@typescript-eslint/parser": "^5.39.0",
+        "colors": "^1.4.0",
+        "diff": "^5.2.0",
         "eslint": "^8.26.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.29.1",
@@ -111,6 +113,24 @@
       },
       "engines": {
         "node": "18"
+      }
+    },
+    "lib/node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "lib/node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "lib/node_modules/typescript": {


### PR DESCRIPTION
This is a quick patch to add color diff to tests without much overhead. We could explore adding `chai` and `chai-diff` in the future, but just adding this as a quick fix.