### PR TITLE
Remove unused LOI subclasses

### DIFF
--- a/web/src/app/components/job-list-item/job-list-item.component.spec.ts
+++ b/web/src/app/components/job-list-item/job-list-item.component.spec.ts
@@ -34,10 +34,7 @@ import {AuditInfo} from 'app/models/audit-info.model';
 import {Coordinate} from 'app/models/geometry/coordinate';
 import {Point} from 'app/models/geometry/point';
 import {Job} from 'app/models/job.model';
-import {
-  GenericLocationOfInterest,
-  LocationOfInterest,
-} from 'app/models/loi.model';
+import {LocationOfInterest} from 'app/models/loi.model';
 import {Submission} from 'app/models/submission/submission.model';
 import {Survey} from 'app/models/survey.model';
 import {GroundIconModule} from 'app/modules/ground-icon.module';
@@ -101,7 +98,7 @@ describe('JobListItemComponent', () => {
     const lois: LocationOfInterest[] = [];
     for (let i = 0; i < count; i++) {
       lois.push(
-        new GenericLocationOfInterest(
+        new LocationOfInterest(
           /* id= */ 'loi' + i,
           /* jobId= */ job.id,
           /* geometry= */ new Point(new Coordinate(1.23, 4.56)),

--- a/web/src/app/components/loi-editor/loi-editor.component.spec.ts
+++ b/web/src/app/components/loi-editor/loi-editor.component.spec.ts
@@ -23,7 +23,7 @@ import {ImportDialogComponent} from 'app/components/import-dialog/import-dialog.
 import {Coordinate} from 'app/models/geometry/coordinate';
 import {Point} from 'app/models/geometry/point';
 import {Job} from 'app/models/job.model';
-import {GenericLocationOfInterest} from 'app/models/loi.model';
+import {LocationOfInterest} from 'app/models/loi.model';
 import {Survey} from 'app/models/survey.model';
 import {DataStoreService} from 'app/services/data-store/data-store.service';
 
@@ -40,7 +40,7 @@ describe('LoiEditorComponent', () => {
   const poiId2 = 'poi002';
   const jobId1 = 'job001';
   const jobId2 = 'job002';
-  const poi1 = new GenericLocationOfInterest(
+  const poi1 = new LocationOfInterest(
     poiId1,
     jobId1,
     new Point(new Coordinate(1.23, 4.56)),
@@ -48,7 +48,7 @@ describe('LoiEditorComponent', () => {
     '',
     true
   );
-  const poi2 = new GenericLocationOfInterest(
+  const poi2 = new LocationOfInterest(
     poiId2,
     jobId2,
     new Point(new Coordinate(12.3, 45.6)),

--- a/web/src/app/components/loi-selection/loi-selection.component.spec.ts
+++ b/web/src/app/components/loi-selection/loi-selection.component.spec.ts
@@ -24,7 +24,7 @@ import {List, Map} from 'immutable';
 import {Coordinate} from 'app/models/geometry/coordinate';
 import {Point} from 'app/models/geometry/point';
 import {Job} from 'app/models/job.model';
-import {GenericLocationOfInterest} from 'app/models/loi.model';
+import {LocationOfInterest} from 'app/models/loi.model';
 import {Survey} from 'app/models/survey.model';
 import {GroundIconModule} from 'app/modules/ground-icon.module';
 import {DataStoreService} from 'app/services/data-store/data-store.service';
@@ -42,13 +42,13 @@ describe('LoiSelectionComponent', () => {
   const poiId2 = 'poi002';
   const jobId1 = 'job001';
   const jobId2 = 'job002';
-  const poi1 = new GenericLocationOfInterest(
+  const poi1 = new LocationOfInterest(
     poiId1,
     jobId1,
     new Point(new Coordinate(1.23, 4.56)),
     Map()
   );
-  const poi2 = new GenericLocationOfInterest(
+  const poi2 = new LocationOfInterest(
     poiId2,
     jobId2,
     new Point(new Coordinate(12.3, 45.6)),

--- a/web/src/app/converters/loi-converter/loi-data-converter.spec.ts
+++ b/web/src/app/converters/loi-converter/loi-data-converter.spec.ts
@@ -19,14 +19,7 @@ import {Map} from 'immutable';
 
 import {GEOMETRY_TYPES, toGeometry} from 'app/converters/geometry-converter';
 import {Geometry, GeometryType} from 'app/models/geometry/geometry';
-import {Point} from 'app/models/geometry/point';
-import {
-  AreaOfInterest,
-  GenericLocationOfInterest,
-  GeoJsonLocationOfInterest,
-  LocationOfInterest,
-  PointOfInterest,
-} from 'app/models/loi.model';
+import {LocationOfInterest} from 'app/models/loi.model';
 
 import {LoiDataConverter} from './loi-data-converter';
 
@@ -60,7 +53,7 @@ describe('toLocationOfInterest', () => {
         geometry: geoPointData,
         properties: {},
       },
-      want: new GenericLocationOfInterest(
+      want: new LocationOfInterest(
         'id0',
         'jobId0',
         geoPoint,
@@ -79,7 +72,7 @@ describe('toLocationOfInterest', () => {
           prop2: '',
         },
       },
-      want: new GenericLocationOfInterest(
+      want: new LocationOfInterest(
         'id0',
         'jobId0',
         geoPoint,
@@ -123,121 +116,6 @@ describe('toLocationOfInterest_Error', () => {
 
   for (const t of testData) {
     const got = LoiDataConverter.toLocationOfInterest(t.inputId, t.inputData);
-    if (!(got instanceof Error)) {
-      throw new Error(`expected error but instead got ${got}`);
-    }
-
-    it(t.expectation, () =>
-      expect((got as Error).message).toContain(t.wantErrorMessage)
-    );
-  }
-});
-
-describe('loiToJS', () => {
-  const geoPointWithError = toGeometry(geoPointData);
-  if (geoPointData instanceof Error) {
-    throw new Error(
-      `got unexpected error in geometry conversion ${geoPointWithError}`
-    );
-  }
-  const geoPoint = geoPointWithError as unknown as GeoPoint;
-  const point = geoPointWithError as unknown as Point;
-
-  const testData: {
-    expectation: string;
-    loi: LocationOfInterest;
-    want: {};
-  }[] = [
-    {
-      expectation: 'converts GenericLocationOfInterest with Point geometry',
-      loi: new GenericLocationOfInterest('id0', 'jobId0', point, Map()),
-      want: {
-        jobId: 'jobId0',
-        geometry: {
-          coordinates: new GeoPoint(point.coord.x, point.coord.y),
-          type: GEOMETRY_TYPES.get(GeometryType.POINT),
-        },
-      },
-    },
-    {
-      expectation: 'converts GeoJsonLocationOfInterest',
-      loi: new GeoJsonLocationOfInterest(
-        'id0',
-        'jobId0',
-        geoPoint,
-        Map<string, string | number>()
-      ),
-      want: {
-        jobId: 'jobId0',
-        geoJson: point,
-      },
-    },
-    {
-      expectation: 'converts AreaOfInterest',
-      loi: new AreaOfInterest(
-        'id0',
-        'jobId0',
-        [geoPoint],
-        Map<string, string | number>()
-      ),
-      want: {
-        jobId: 'jobId0',
-        polygonVertices: [point],
-      },
-    },
-    {
-      expectation: 'converts empty AreaOfInterest',
-      loi: new AreaOfInterest(
-        'id0',
-        'jobId0',
-        [],
-        Map<string, string | number>()
-      ),
-      want: {
-        jobId: 'jobId0',
-        polygonVertices: [],
-      },
-    },
-  ];
-
-  for (const t of testData) {
-    const got = LoiDataConverter.loiToJS(t.loi);
-    if (got instanceof Error) {
-      throw new Error(`got unexpected error ${got}`);
-    }
-
-    it(t.expectation, () => expect(got as {}).toEqual(t.want));
-  }
-});
-
-describe('loiToJS_Error', () => {
-  const geoPointWithError = toGeometry(geoPointData);
-  if (geoPointData instanceof Error) {
-    throw new Error(
-      `got unexpected error in geometry conversion ${geoPointWithError}`
-    );
-  }
-  const geoPoint = geoPointWithError as unknown as GeoPoint;
-
-  const testData: {
-    expectation: string;
-    loi: LocationOfInterest;
-    wantErrorMessage: string;
-  }[] = [
-    {
-      expectation: 'Cannot convert PointOfInterest',
-      loi: new PointOfInterest(
-        'id0',
-        'jobId0',
-        geoPoint,
-        Map<string, string | number>()
-      ),
-      wantErrorMessage: 'Cannot convert unexpected loi class',
-    },
-  ];
-
-  for (const t of testData) {
-    const got = LoiDataConverter.loiToJS(t.loi);
     if (!(got instanceof Error)) {
       throw new Error(`expected error but instead got ${got}`);
     }

--- a/web/src/app/converters/loi-converter/loi-data-converter.ts
+++ b/web/src/app/converters/loi-converter/loi-data-converter.ts
@@ -14,18 +14,11 @@
  * limitations under the License.
  */
 import {DocumentData} from '@angular/fire/firestore';
-import {GeoPoint} from 'firebase/firestore';
 import {Map} from 'immutable';
 
-import {GEOMETRY_TYPES, toGeometry} from 'app/converters/geometry-converter';
+import {toGeometry} from 'app/converters/geometry-converter';
 import {Geometry} from 'app/models/geometry/geometry';
-import {Point} from 'app/models/geometry/point';
-import {
-  AreaOfInterest,
-  GenericLocationOfInterest,
-  GeoJsonLocationOfInterest,
-  LocationOfInterest,
-} from 'app/models/loi.model';
+import {LocationOfInterest} from 'app/models/loi.model';
 
 /**
  * Helper to return either the keys of a dictionary, or if missing, returns an
@@ -62,7 +55,7 @@ export class LoiDataConverter {
         return result;
       }
 
-      return new GenericLocationOfInterest(
+      return new LocationOfInterest(
         id,
         data.jobId,
         result as Geometry,
@@ -73,40 +66,6 @@ export class LoiDataConverter {
     } catch (err) {
       return new Error(
         `Error converting to LOI: invalid LOI in remote data store; data: ${data}, error message: ${err}`
-      );
-    }
-  }
-
-  // TODO(Nick): Add polygon / multipolygon conversion, remove AreaOfInterest
-  // and GeoJsonLocationOfInterest. This may not be urgent, as only point
-  // conversion seems to be used on the frontend.
-  public static loiToJS(loi: LocationOfInterest): {} | Error {
-    // TODO: Set audit info (created / last modified user and timestamp).
-    if (loi.geometry instanceof Point) {
-      // TODO: Add geometryToJS converters in geometry-converter.ts call it from here. Then GEOMETRY_TYPES can be local.
-      const {jobId, geometry} = loi;
-      return {
-        jobId,
-        geometry: {
-          coordinates: new GeoPoint(geometry.coord.x, geometry.coord.y),
-          type: GEOMETRY_TYPES.get(geometry.geometryType),
-        },
-      };
-    } else if (loi instanceof GeoJsonLocationOfInterest) {
-      const {jobId, geoJson} = loi;
-      return {
-        jobId,
-        geoJson,
-      };
-    } else if (loi instanceof AreaOfInterest) {
-      const {jobId, polygonVertices} = loi;
-      return {
-        jobId,
-        polygonVertices,
-      };
-    } else {
-      return new Error(
-        `Cannot convert unexpected loi class ${loi.constructor.name} to json.`
       );
     }
   }

--- a/web/src/app/models/loi.model.ts
+++ b/web/src/app/models/loi.model.ts
@@ -14,70 +14,11 @@
  * limitations under the License.
  */
 
-import {GeoPoint} from 'firebase/firestore';
 import {List, Map} from 'immutable';
 
 import {Geometry} from './geometry/geometry';
 
-export abstract class LocationOfInterest {
-  abstract readonly id: string;
-  abstract readonly jobId: string;
-  abstract readonly name?: string;
-  // TODO(#1444): Make non-null once other subtypes are removed.
-  abstract readonly geometry?: Geometry;
-  // TODO(#1444): Make non-null, init to empty by default.
-  abstract readonly properties?: Map<string, string | number>;
-  abstract readonly customId: string;
-  abstract readonly predefined?: boolean;
-
-  static getSmallestByArea(lois: List<LocationOfInterest>): LocationOfInterest {
-    return lois
-      .sort((a, b) =>
-        (a.geometry?.getArea() || 0) < (b.geometry?.getArea() || 0) ? -1 : 1
-      )
-      .first();
-  }
-}
-
-// TODO(#1444): Delete me in favor of single LOI type.
-export class PointOfInterest implements LocationOfInterest {
-  constructor(
-    readonly id: string,
-    readonly jobId: string,
-    // TODO(#1444): User custom type instead of exposing types from data job.
-    readonly location: GeoPoint,
-    readonly properties?: Map<string, string | number>,
-    readonly customId: string = '',
-    readonly predefined: boolean = true
-  ) {}
-}
-
-// TODO(#1444): Delete me in favor of single LOI type.
-export class GeoJsonLocationOfInterest implements LocationOfInterest {
-  constructor(
-    readonly id: string,
-    readonly jobId: string,
-    readonly geoJson: object,
-    readonly properties?: Map<string, string | number>,
-    readonly customId: string = '',
-    readonly predefined: boolean = true
-  ) {}
-}
-
-// TODO(#1444): Delete me in favor of single LOI type.
-export class AreaOfInterest implements LocationOfInterest {
-  constructor(
-    readonly id: string,
-    readonly jobId: string,
-    readonly polygonVertices: GeoPoint[],
-    readonly properties?: Map<string, string | number>,
-    readonly customId: string = '',
-    readonly predefined: boolean = true
-  ) {}
-}
-
-// TODO(#1444): Merge into LocationOfInterest and make concrete.
-export class GenericLocationOfInterest implements LocationOfInterest {
+export class LocationOfInterest {
   constructor(
     readonly id: string,
     readonly jobId: string,
@@ -86,4 +27,12 @@ export class GenericLocationOfInterest implements LocationOfInterest {
     readonly customId: string = '',
     readonly predefined: boolean = true
   ) {}
+
+  static getSmallestByArea(lois: List<LocationOfInterest>): LocationOfInterest {
+    return lois
+      .sort((a, b) =>
+        (a.geometry?.getArea() || 0) < (b.geometry?.getArea() || 0) ? -1 : 1
+      )
+      .first();
+  }
 }

--- a/web/src/app/pages/main-page-container/main-page/map/map.component.spec.ts
+++ b/web/src/app/pages/main-page-container/main-page/map/map.component.spec.ts
@@ -31,10 +31,7 @@ import {Coordinate} from 'app/models/geometry/coordinate';
 import {MultiPolygon} from 'app/models/geometry/multi-polygon';
 import {Point} from 'app/models/geometry/point';
 import {Job} from 'app/models/job.model';
-import {
-  GenericLocationOfInterest,
-  LocationOfInterest,
-} from 'app/models/loi.model';
+import {LocationOfInterest} from 'app/models/loi.model';
 import {Submission} from 'app/models/submission/submission.model';
 import {Survey} from 'app/models/survey.model';
 import {AuthService} from 'app/services/auth/auth.service';
@@ -96,25 +93,25 @@ describe('MapComponent', () => {
     }),
     /* acl= */ Map()
   );
-  const poi1 = new GenericLocationOfInterest(
+  const poi1 = new LocationOfInterest(
     poiId1,
     jobId1,
     new Point(new Coordinate(1.23, 4.56)),
     Map()
   );
-  const poi2 = new GenericLocationOfInterest(
+  const poi2 = new LocationOfInterest(
     poiId2,
     jobId2,
     new Point(new Coordinate(12.3, 45.6)),
     Map()
   );
-  const poi3 = new GenericLocationOfInterest(
+  const poi3 = new LocationOfInterest(
     poiId3,
     jobId2,
     new Point(new Coordinate(78.9, 78.9)),
     Map()
   );
-  const poi4 = new GenericLocationOfInterest(
+  const poi4 = new LocationOfInterest(
     poiId4,
     jobId2,
     new Point(new Coordinate(45, 45)),
@@ -141,13 +138,13 @@ describe('MapComponent', () => {
     [20, -10],
     [-10, -10],
   ];
-  const polygonLoi1 = new GenericLocationOfInterest(
+  const polygonLoi1 = new LocationOfInterest(
     polygonLoiId1,
     jobId1,
     polygonShellCoordsToPolygon(polygon1ShellCoordinates),
     Map()
   );
-  const multipolygonLoi1 = new GenericLocationOfInterest(
+  const multipolygonLoi1 = new LocationOfInterest(
     multipolygonLoiId1,
     jobId1,
     new MultiPolygon(
@@ -343,13 +340,13 @@ describe('MapComponent', () => {
 
   describe('when backend LOIs update', () => {
     it('should update lois when backend lois update', fakeAsync(() => {
-      const poi2Modified = new GenericLocationOfInterest(
+      const poi2Modified = new LocationOfInterest(
         poiId2,
         jobId2,
         new Point(new Coordinate(12.3, 45.7)),
         Map()
       );
-      const polygonLoi1Modified = new GenericLocationOfInterest(
+      const polygonLoi1Modified = new LocationOfInterest(
         polygonLoiId1,
         jobId1,
         polygonShellCoordsToPolygon(polygon1ShellCoordinatesModified),
@@ -560,7 +557,7 @@ describe('MapComponent', () => {
 
     assertMarkerLatLng(marker, new google.maps.LatLng(2.23, 5.56));
     expect(loiServiceSpy.updatePoint).toHaveBeenCalledOnceWith(
-      new GenericLocationOfInterest(
+      new LocationOfInterest(
         poi1.id,
         poi1.jobId,
         new Point(new Coordinate(5.56, 2.23)),

--- a/web/src/app/pages/main-page-container/main-page/map/map.component.ts
+++ b/web/src/app/pages/main-page-container/main-page/map/map.component.ts
@@ -33,10 +33,7 @@ import {Geometry, GeometryType} from 'app/models/geometry/geometry';
 import {MultiPolygon} from 'app/models/geometry/multi-polygon';
 import {Point} from 'app/models/geometry/point';
 import {Polygon} from 'app/models/geometry/polygon';
-import {
-  GenericLocationOfInterest,
-  LocationOfInterest,
-} from 'app/models/loi.model';
+import {LocationOfInterest} from 'app/models/loi.model';
 import {Submission} from 'app/models/submission/submission.model';
 import {Survey} from 'app/models/survey.model';
 import {TaskType} from 'app/models/task/task.model';
@@ -97,7 +94,7 @@ export class MapComponent implements AfterViewInit, OnChanges, OnDestroy {
   };
   mapOptions: google.maps.MapOptions = this.initialMapOptions;
   showRepositionConfirmDialog = false;
-  newLocationOfInterestToReposition?: GenericLocationOfInterest;
+  newLocationOfInterestToReposition?: LocationOfInterest;
   oldLatLng?: google.maps.LatLng;
   newLatLng?: google.maps.LatLng;
   markerToReposition?: google.maps.Marker;
@@ -512,7 +509,7 @@ export class MapComponent implements AfterViewInit, OnChanges, OnDestroy {
       event.latLng!.lng()
     );
 
-    this.newLocationOfInterestToReposition = new GenericLocationOfInterest(
+    this.newLocationOfInterestToReposition = new LocationOfInterest(
       id,
       jobId,
       new Point(new Coordinate(event.latLng!.lng(), event.latLng!.lat())),

--- a/web/src/app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel-header/loi-panel-header.component.spec.ts
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel-header/loi-panel-header.component.spec.ts
@@ -30,10 +30,7 @@ import {LinearRing} from 'app/models/geometry/linear-ring';
 import {MultiPolygon} from 'app/models/geometry/multi-polygon';
 import {Point} from 'app/models/geometry/point';
 import {Polygon} from 'app/models/geometry/polygon';
-import {
-  GenericLocationOfInterest,
-  LocationOfInterest,
-} from 'app/models/loi.model';
+import {LocationOfInterest} from 'app/models/loi.model';
 import {LocationOfInterestPanelHeaderComponent} from 'app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel-header/loi-panel-header.component';
 import {LocationOfInterestService} from 'app/services/loi/loi.service';
 import {NavigationService} from 'app/services/navigation/navigation.service';
@@ -55,7 +52,7 @@ describe('LocationOfInterestPanelHeaderComponent', () => {
   let fixture: ComponentFixture<LocationOfInterestPanelHeaderComponent>;
   let mockSelectedLoi$: BehaviorSubject<LocationOfInterest>;
 
-  const pointLocationOfInterest = new GenericLocationOfInterest(
+  const pointLocationOfInterest = new LocationOfInterest(
     'somePoint',
     'someJob',
     new Point(new Coordinate(1.23, 4.56)),
@@ -78,13 +75,13 @@ describe('LocationOfInterestPanelHeaderComponent', () => {
     ),
     List()
   );
-  const polygonLocationOfInterest = new GenericLocationOfInterest(
+  const polygonLocationOfInterest = new LocationOfInterest(
     'somePolygon',
     'someJob',
     polygon1,
     Map()
   );
-  const multiPolygonLocationOfInterest = new GenericLocationOfInterest(
+  const multiPolygonLocationOfInterest = new LocationOfInterest(
     'someMultiPolygon',
     'someJob',
     new MultiPolygon(List([polygon1, polygon2])),

--- a/web/src/app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel.component.spec.ts
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/loi-panel/loi-panel.component.spec.ts
@@ -24,10 +24,7 @@ import {of} from 'rxjs';
 import {Coordinate} from 'app/models/geometry/coordinate';
 import {Point} from 'app/models/geometry/point';
 import {Job} from 'app/models/job.model';
-import {
-  GenericLocationOfInterest,
-  LocationOfInterest,
-} from 'app/models/loi.model';
+import {LocationOfInterest} from 'app/models/loi.model';
 import {Submission} from 'app/models/submission/submission.model';
 import {Survey} from 'app/models/survey.model';
 import {DataStoreService} from 'app/services/data-store/data-store.service';
@@ -54,7 +51,7 @@ const mockSurvey = new Survey(
   /* acl= */ Map()
 );
 
-const mockLocationOfInterest = new GenericLocationOfInterest(
+const mockLocationOfInterest = new LocationOfInterest(
   'loi001',
   'job001',
   new Point(new Coordinate(0.0, 0.0)),

--- a/web/src/app/pages/main-page-container/main-page/side-panel/submission-form/submission-form.component.spec.ts
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/submission-form/submission-form.component.spec.ts
@@ -35,10 +35,7 @@ import {AuditInfo} from 'app/models/audit-info.model';
 import {Coordinate} from 'app/models/geometry/coordinate';
 import {Point} from 'app/models/geometry/point';
 import {Job} from 'app/models/job.model';
-import {
-  GenericLocationOfInterest,
-  LocationOfInterest,
-} from 'app/models/loi.model';
+import {LocationOfInterest} from 'app/models/loi.model';
 import {Result} from 'app/models/submission/result.model';
 import {Submission} from 'app/models/submission/submission.model';
 import {Survey} from 'app/models/survey.model';
@@ -110,7 +107,7 @@ class MockModel {
     /*acl=*/ Map({})
   );
 
-  static loi001 = new GenericLocationOfInterest(
+  static loi001 = new LocationOfInterest(
     'loi001',
     MockModel.job001.id,
     new Point(new Coordinate(0.0, 0.0)),

--- a/web/src/app/services/data-store/data-store.service.ts
+++ b/web/src/app/services/data-store/data-store.service.ts
@@ -467,23 +467,6 @@ export class DataStoreService {
     return serverTimestamp();
   }
 
-  updateLocationOfInterest(
-    surveyId: string,
-    loi: LocationOfInterest
-  ): Promise<void> {
-    const loiJs = LoiDataConverter.loiToJS(loi);
-    if (loiJs instanceof Error) {
-      throw loiJs;
-    }
-
-    return this.db
-      .collection(SURVEYS_COLLECTION_NAME)
-      .doc(surveyId)
-      .collection('lois')
-      .doc(loi.id)
-      .set(loiJs);
-  }
-
   /**
    * Creates a new survey in the remote db using the specified title,
    * returning the id of the newly created survey. ACLs are initialized

--- a/web/src/app/services/loi/loi.service.spec.ts
+++ b/web/src/app/services/loi/loi.service.spec.ts
@@ -21,7 +21,7 @@ import {Subject, of} from 'rxjs';
 import {Coordinate} from 'app/models/geometry/coordinate';
 import {MultiPolygon} from 'app/models/geometry/multi-polygon';
 import {Point} from 'app/models/geometry/point';
-import {GenericLocationOfInterest} from 'app/models/loi.model';
+import {LocationOfInterest} from 'app/models/loi.model';
 import {Survey} from 'app/models/survey.model';
 import {User} from 'app/models/user.model';
 import {AuthService} from 'app/services/auth/auth.service';
@@ -39,7 +39,7 @@ describe('LocationOfInterestService', () => {
     properties: ImmutableMap<string, string | number> = ImmutableMap(),
     customId = ''
   ) => {
-    return new GenericLocationOfInterest(
+    return new LocationOfInterest(
       'loi001',
       'job001',
       new Point(new Coordinate(0.0, 0.0)),
@@ -93,7 +93,7 @@ describe('LocationOfInterestService', () => {
 
   describe('getLatLngBoundsFromLois', () => {
     const jobId1 = 'job001';
-    const poi1 = new GenericLocationOfInterest(
+    const poi1 = new LocationOfInterest(
       'poi001',
       jobId1,
       new Point(new Coordinate(30, 30)),
@@ -113,13 +113,13 @@ describe('LocationOfInterestService', () => {
       [20, -10],
       [-10, -10],
     ];
-    const polygonLoi1 = new GenericLocationOfInterest(
+    const polygonLoi1 = new LocationOfInterest(
       'polygon_loi001',
       jobId1,
       polygonShellCoordsToPolygon(polygon1ShellCoordinates),
       Map()
     );
-    const multipolygonLoi1 = new GenericLocationOfInterest(
+    const multipolygonLoi1 = new LocationOfInterest(
       'multipolygon_loi001',
       jobId1,
       new MultiPolygon(

--- a/web/src/app/services/loi/loi.service.ts
+++ b/web/src/app/services/loi/loi.service.ts
@@ -22,10 +22,7 @@ import {map, switchMap} from 'rxjs/operators';
 import {Coordinate} from 'app/models/geometry/coordinate';
 import {GeometryType} from 'app/models/geometry/geometry';
 import {Point} from 'app/models/geometry/point';
-import {
-  GenericLocationOfInterest,
-  LocationOfInterest,
-} from 'app/models/loi.model';
+import {LocationOfInterest} from 'app/models/loi.model';
 import {Survey} from 'app/models/survey.model';
 import {AuthService} from 'app/services/auth/auth.service';
 import {DataStoreService} from 'app/services/data-store/data-store.service';
@@ -161,45 +158,10 @@ export class LocationOfInterestService {
     lng: number,
     jobId: string
   ): Promise<LocationOfInterest | null> {
-    // TODO: Update to use `await firstValueFrom(getActiveSurvey$()` when
-    // upgrading to RxJS 7.
-    const survey = await firstValueFrom(this.surveyService.getActiveSurvey$());
-    return await this.addPointInternal(survey, lat, lng, jobId);
+    throw new Error('Adding LOIs via web app not yet supported');
   }
 
   async updatePoint(loi: LocationOfInterest): Promise<void> {
-    // TODO: Update to use `await firstValueFrom(getActiveSurvey$()` when
-    // upgrading to RxJS 7.
-    const survey = await firstValueFrom(this.surveyService.getActiveSurvey$());
-    return await this.updatePointInternal(survey, loi);
-  }
-
-  private async addPointInternal(
-    survey: Survey,
-    lat: number,
-    lng: number,
-    jobId: string
-  ): Promise<LocationOfInterest | null> {
-    if (!(survey.jobs || new Map()).get(jobId)) {
-      return null;
-    }
-    const newLocationOfInterest = new GenericLocationOfInterest(
-      this.dataStore.generateId(),
-      jobId,
-      new Point(new Coordinate(lng, lat)),
-      ImmutableMap()
-    );
-    await this.dataStore.updateLocationOfInterest(
-      survey.id,
-      newLocationOfInterest
-    );
-    return newLocationOfInterest;
-  }
-
-  private async updatePointInternal(survey: Survey, loi: LocationOfInterest) {
-    if (survey.jobs.isEmpty()) {
-      return;
-    }
-    await this.dataStore.updateLocationOfInterest(survey.id, loi);
+    throw new Error('Editing LOIs via web app not yet supported');
   }
 }

--- a/web/src/testing/test-data.ts
+++ b/web/src/testing/test-data.ts
@@ -18,7 +18,6 @@ import {GeoPoint} from 'firebase/firestore';
 import {Map} from 'immutable';
 
 import {DataCollectionStrategy, Job} from 'app/models/job.model';
-import {PointOfInterest} from 'app/models/loi.model';
 import {Role} from 'app/models/role.model';
 import {Survey} from 'app/models/survey.model';
 import {Task} from 'app/models/task/task.model';
@@ -60,9 +59,5 @@ export class TestData {
     strategy = DataCollectionStrategy.PREDEFINED,
   }): Job {
     return new Job(id, index, color, name, Map(tasks), strategy);
-  }
-
-  public static newPointOfInterest(): PointOfInterest {
-    return new PointOfInterest('loi001', 'job001', new GeoPoint(0, 0), Map());
   }
 }


### PR DESCRIPTION
This PR also removes unused code related to adding points via drawing tools and related tests. We don't full excise drawing tools code since it's quite certain they will be needed in the future, but the backend impl will have changed so much by then it doesn't make sense to carry the old serialization code forward.

@DaoyuT or @nwkotto PTAL?