### PR TITLE
Small fixes to task proto serialization

### DIFF
--- a/lib/src/proto-to-firestore.ts
+++ b/lib/src/proto-to-firestore.ts
@@ -23,7 +23,10 @@ import {DocumentData, DocumentFieldValue} from '@google-cloud/firestore';
  * The map is keyed by message field numbers represented as strings, while field values are
  * converted to corresponding Firestore data types.
  */
-export function toDocumentData(message: object): DocumentData {
+export function toDocumentData(message: object): DocumentData|DocumentData[] {
+  if (Array.isArray(message)) {
+    return message.map((messageEl) => toDocumentData(messageEl));
+  }
   if (Object.keys(message).length === 0) {
     return {};
   }

--- a/lib/src/proto-to-firestore.ts
+++ b/lib/src/proto-to-firestore.ts
@@ -23,9 +23,9 @@ import {DocumentData, DocumentFieldValue} from '@google-cloud/firestore';
  * The map is keyed by message field numbers represented as strings, while field values are
  * converted to corresponding Firestore data types.
  */
-export function toDocumentData(message: object): DocumentData|DocumentData[] {
+export function toDocumentData(message: object): DocumentData | DocumentData[] {
   if (Array.isArray(message)) {
-    return message.map((messageEl) => toDocumentData(messageEl));
+    return message.map(messageEl => toDocumentData(messageEl));
   }
   if (Object.keys(message).length === 0) {
     return {};

--- a/lib/src/testing/firestore/firestore.ts
+++ b/lib/src/testing/firestore/firestore.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Firestore } from "@google-cloud/firestore";
+import {Firestore} from '@google-cloud/firestore';
 
 const MockFirebase = require('mock-cloud-firestore');
 
@@ -30,9 +30,8 @@ export function createMockFirestore(): Firestore {
  * in tests to work around lack of support in MockFirebase lib.
  */
 export function TestGeoPoint(_latitude: number, _longitude: number) {
-    return {
-      _latitude,
-      _longitude,
-    };
-  }
-  
+  return {
+    _latitude,
+    _longitude,
+  };
+}

--- a/lib/src/testing/firestore/index.ts
+++ b/lib/src/testing/firestore/index.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-export * from "./firestore";
-export * from "./event-context";
-export * from "./document-snapshot";
-export * from "./query";
-export * from "./setup";
+export * from './firestore';
+export * from './event-context';
+export * from './document-snapshot';
+export * from './query';
+export * from './setup';

--- a/lib/src/testing/reporter.js
+++ b/lib/src/testing/reporter.js
@@ -19,7 +19,7 @@ import {SpecReporter, StacktraceOption} from 'jasmine-spec-reporter';
 // Show references to TypeScript code in stacktraces.
 require('source-map-support').install();
 
-jasmine.getEnv().clearReporters()
+jasmine.getEnv().clearReporters();
 jasmine.getEnv().addReporter(
   new SpecReporter({
     spec: {
@@ -27,4 +27,4 @@ jasmine.getEnv().addReporter(
       displayStacktrace: StacktraceOption.RAW,
     },
   })
-)
+);

--- a/web/src/app/converters/proto-model-converter.ts
+++ b/web/src/app/converters/proto-model-converter.ts
@@ -103,7 +103,10 @@ export function jobToDocument(job: Job): DocumentData {
       index: job.index,
       name: job.name,
       style: new Pb.Style({color: job.color}),
-      tasks: job.tasks?.toList().map((task: Task) => toTaskMessage(task)).toArray(),
+      tasks: job.tasks
+        ?.toList()
+        .map((task: Task) => toTaskMessage(task))
+        .toArray(),
     })
   );
 }

--- a/web/src/app/converters/proto-model-converter.ts
+++ b/web/src/app/converters/proto-model-converter.ts
@@ -103,13 +103,9 @@ export function jobToDocument(job: Job): DocumentData {
       index: job.index,
       name: job.name,
       style: new Pb.Style({color: job.color}),
-      tasks: job.tasks?.toList().map(toTaskMessage).toArray(),
+      tasks: job.tasks?.toList().map((task: Task) => toTaskMessage(task)).toArray(),
     })
   );
-}
-
-export function tasksToDocument(tasks: List<Task>): DocumentData {
-  return toDocumentData(tasks.toList().map(toTaskMessage).toArray());
 }
 
 /**
@@ -192,7 +188,7 @@ function toTaskTypeMessage(
     case TaskType.CAPTURE_LOCATION:
       return {
         captureLocation: new Pb.Task.CaptureLocation({
-          minAccuracyMeters: null,
+          minAccuracyMeters: 0,
         }),
       };
     default:
@@ -222,7 +218,7 @@ function toTaskConditionMessage(
 }
 
 /**
- * Returns a Protobuf messager epresenting a Task model.
+ * Returns a Protobuf message representing a Task model.
  */
 function toTaskMessage(task: Task): Pb.ITask {
   return new Pb.Task({
@@ -232,8 +228,8 @@ function toTaskMessage(task: Task): Pb.ITask {
     prompt: task.label,
     required: task.required,
     level: task.addLoiTask
-      ? Pb.Task.DataCollectionLevel.LOI_DATA
-      : Pb.Task.DataCollectionLevel.LOI_METADATA,
+      ? Pb.Task.DataCollectionLevel.LOI_METADATA
+      : Pb.Task.DataCollectionLevel.LOI_DATA,
     conditions: toTaskConditionMessage(task.condition),
   });
 }

--- a/web/src/app/converters/proto-model-converter.ts
+++ b/web/src/app/converters/proto-model-converter.ts
@@ -96,15 +96,17 @@ export function aclToDocument(acl: Map<string, Role>): DocumentData | Error {
 /**
  * Returns the proto representation of a Job model object.
  */
-export function jobToDocument(job: Job): DocumentData {
+export function jobToDocument(
+  job: Job,
+  taskOverride: List<Task> | null = null
+): DocumentData {
   return toDocumentData(
     new Pb.Job({
       id: job.id,
       index: job.index,
       name: job.name,
       style: new Pb.Style({color: job.color}),
-      tasks: job.tasks
-        ?.toList()
+      tasks: (taskOverride ?? job.tasks?.toList() ?? List())
         .map((task: Task) => toTaskMessage(task))
         .toArray(),
     })

--- a/web/src/app/pages/create-survey/create-survey.component.ts
+++ b/web/src/app/pages/create-survey/create-survey.component.ts
@@ -268,7 +268,7 @@ export class CreateSurveyComponent implements OnInit {
     await this.taskService.addOrUpdateTasks(
       survey.id,
       // Assume there is at least one job.
-      survey.jobs.first()!.id,
+      survey.jobs.first(),
       tasks!
     );
   }

--- a/web/src/app/services/data-store/data-store.service.ts
+++ b/web/src/app/services/data-store/data-store.service.ts
@@ -37,7 +37,6 @@ import {
   jobToDocument,
   newSurveyToDocument,
   partialSurveyToDocument,
-  tasksToDocument,
 } from 'app/converters/proto-model-converter';
 import {Job} from 'app/models/job.model';
 import {LocationOfInterest} from 'app/models/loi.model';
@@ -539,7 +538,6 @@ export class DataStoreService {
       .update({
         [`jobs.${jobId}.tasks`]: {
           ...FirebaseDataConverter.tasksToJS(this.convertTasksListToMap(tasks)),
-          ...tasksToDocument(tasks),
         },
       });
   }

--- a/web/src/app/services/data-store/data-store.service.ts
+++ b/web/src/app/services/data-store/data-store.service.ts
@@ -244,7 +244,7 @@ export class DataStoreService {
   updateJob(
     surveyId: string,
     job: Job,
-    tasks: List<Task> | undefined = undefined
+    tasks: List<Task> | null = null
   ): Promise<void> {
     return this.db
       .collection(`${SURVEYS_COLLECTION_NAME}/${surveyId}/jobs`)

--- a/web/src/app/services/task/task.service.ts
+++ b/web/src/app/services/task/task.service.ts
@@ -18,7 +18,7 @@ import {Injectable} from '@angular/core';
 import {List, Map} from 'immutable';
 import {Observable, switchMap} from 'rxjs';
 
-import {DataCollectionStrategy} from 'app/models/job.model';
+import {DataCollectionStrategy, Job} from 'app/models/job.model';
 import {MultipleChoice} from 'app/models/task/multiple-choice.model';
 import {Task, TaskType} from 'app/models/task/task.model';
 import {DataStoreService} from 'app/services/data-store/data-store.service';
@@ -101,10 +101,10 @@ export class TaskService {
 
   addOrUpdateTasks(
     surveyId: string,
-    jobId: string,
+    job: Job,
     tasks: List<Task>
-  ): Promise<void> {
-    return this.dataStoreService.addOrUpdateTasks(surveyId, jobId, tasks);
+  ): Promise<[void, void]> {
+    return this.dataStoreService.addOrUpdateTasks(surveyId, job, tasks);
   }
 
   /**


### PR DESCRIPTION
Fixes #1911
Fixes #1922
Fixes #1921

Ensures that tasks are properly serialized to proto and are updated on task creation step.

- [x] Calls `updateJob()` on `addOrUpdateTask()` routine to ensure that we serialize the task proto at the right time.
- [x] Added a task list parameter override to account for the job's tasks list to be readonly
- [x] Supports arrays when serializing task list into proto
- [x] Don't serialize task protos in survey > job > tasks, since we are parsing them from `/jobs` instead.
- [x] Fixed issue with swapped LOI_METADATA and LOI_DATA fields.
- [x] Fixed issue with `minAccuracyMeters` set to null instead of a default value --> gets optimized out. 
- [x] Tested on local web server