### PR TITLE
[Proto] Serialize time task as "TIME_ONLY"

### DIFF
--- a/web/src/app/components/tasks-editor/task-form/task-form.component.ts
+++ b/web/src/app/components/tasks-editor/task-form/task-form.component.ts
@@ -90,7 +90,7 @@ export const TaskTypeOptions: Array<TaskTypeOption> = [
   {
     icon: 'access_time',
     label: 'Time',
-    type: TaskType.DATE_TIME,
+    type: TaskType.TIME,
   },
 ];
 

--- a/web/src/app/converters/firebase-data-converter.ts
+++ b/web/src/app/converters/firebase-data-converter.ts
@@ -48,6 +48,7 @@ const TASK_TYPE_ENUMS_BY_STRING = Map([
   [TaskType.TEXT, 'text_field'],
   [TaskType.DATE, 'date'],
   [TaskType.MULTIPLE_CHOICE, 'multiple_choice'],
+  [TaskType.TIME, 'time'],
   [TaskType.DATE_TIME, 'date_time'],
   [TaskType.NUMBER, 'number'],
   [TaskType.PHOTO, 'photo'],


### PR DESCRIPTION
Fixes #1925 

Ensures that we serialize time tasks as "time" for the non-proto serialization and "TIME_ONLY" for the proto serialization. Before, it was serializing as `DATE_TIME` which converted to `BOTH_DATE_AND_TIME` which was not correct.

Verified using the local web server and local app client.
