### PR TITLE
Reverted PR 1990

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10772,10 +10772,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.5.tgz",
-      "integrity": "sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==",
+      "version": "1.7.2",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -27669,10 +27668,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.3.tgz",
-      "integrity": "sha512-HaYi2CVjiPoBR1d2zTVKVHXr9IUnpJizCjUu19vxdD3B8o4z+vfOHpIEB1358w8nv8dfUNEfDHFvMsH7QlLt/Q==",
+      "version": "7.3.2",
       "hasInstallScript": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",


### PR DESCRIPTION
PR 1990 (https://github.com/google/ground-platform/pull/1990) causes the following error: 

```
src/message-registry.ts:139:3 - error TS2352: Conversion of type '{ options: { syntax: string; }; nested: { ground: { nested: { v1beta1: { options: { java_multiple_files: boolean; java_package: string; }; nested: { AuditInfo: { fields: { userId: { type: string; id: number; }; ... 4 more ...; emailAddress: { ...; }; }; }; ... 13 more ...; Role: { ...; }; }; }; }; }; google: { ...; ...' to type 'MessageRegistryJson' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
  Types of property 'options' are incompatible.
    Type '{ syntax: string; }' is missing the following properties from type 'ProtoOptions': java_package, java_multiple_files

139   registryJson as MessageRegistryJson
```