### PR TITLE
Inverted free-form/predefined sample sites boxes

### DIFF
--- a/web/src/app/components/loi-editor/loi-editor.component.html
+++ b/web/src/app/components/loi-editor/loi-editor.component.html
@@ -15,6 +15,24 @@
 -->
 
 <div class="loi-editor">
+  <div class="loi-editor-card">
+    <div class="loi-editor-card-row">
+      <div class="loi-editor-card-row-content">
+        <div class="loi-editor-card-row-title">Free-form data collection</div>
+        <div class="loi-editor-card-row-subtitle">Allow data collectors to add and collect data about new locations as they go.</div>
+      </div>
+
+      <div class="loi-editor-card-actions">
+        <mat-slide-toggle
+          [checked]="job?.strategy === DataCollectionStrategy.MIXED"
+          (change)="toggleDataCollectorsCanAddLois($event)"
+          color="primary"
+        >
+        </mat-slide-toggle>
+      </div>
+    </div>
+  </div>
+
   <div class="loi-editor-card" *ngIf="canImport">
     <div class="loi-editor-card-row">
       <div class="loi-editor-card-row-content">
@@ -53,24 +71,6 @@
         [jobId]="job?.id"
       >
       </loi-selection>
-    </div>
-  </div>
-
-  <div class="loi-editor-card">
-    <div class="loi-editor-card-row">
-      <div class="loi-editor-card-row-content">
-        <div class="loi-editor-card-row-title">Free-form data collection</div>
-        <div class="loi-editor-card-row-subtitle">Allow data collectors to add and collect data about new locations as they go.</div>
-      </div>
-
-      <div class="loi-editor-card-actions">
-        <mat-slide-toggle
-          [checked]="job?.strategy === DataCollectionStrategy.MIXED"
-          (change)="toggleDataCollectorsCanAddLois($event)"
-          color="primary"
-        >
-        </mat-slide-toggle>
-      </div>
     </div>
   </div>
 </div>

--- a/web/src/app/pages/create-survey/create-survey.component.html
+++ b/web/src/app/pages/create-survey/create-survey.component.html
@@ -18,14 +18,14 @@
   <ground-header></ground-header>
 
   <!-- TODO(#1170): Extract the spinner into a component -->
-  <div id="loading-spinner" class="loading-spinner" *ngIf="!survey">
+  <div id="loading-spinner" class="loading-spinner" *ngIf="setupPhase === SetupPhase.LOADING">
     <div>
       <mat-spinner></mat-spinner>
       <p class="loading-label">Loading survey...</p>
     </div>
   </div>
 
-  <div *ngIf="survey" class="container">
+  <div *ngIf="setupPhase !== SetupPhase.LOADING" class="container">
     <div class="card">
       <img
         *ngIf="setupPhase === SetupPhase.JOB_DETAILS"

--- a/web/src/app/pages/create-survey/survey-loi/survey-loi.component.ts
+++ b/web/src/app/pages/create-survey/survey-loi/survey-loi.component.ts
@@ -16,7 +16,6 @@
 
 import {Component} from '@angular/core';
 import {List} from 'immutable';
-import {Observable} from 'rxjs';
 
 import {DataCollectionStrategy, Job} from 'app/models/job.model';
 import {LocationOfInterest} from 'app/models/loi.model';
@@ -48,10 +47,6 @@ export class SurveyLoiComponent {
     this.loiService
       .getPredefinedLoisByJobId$(this.job.id)
       .subscribe(lois => (this.lois = lois));
-
-    await this.onStrategyChange(
-      this.job?.strategy || DataCollectionStrategy.PREDEFINED
-    );
   }
 
   async onStrategyChange(strategy: DataCollectionStrategy) {

--- a/web/src/app/services/job/job.service.ts
+++ b/web/src/app/services/job/job.service.ts
@@ -18,9 +18,10 @@ import {Injectable} from '@angular/core';
 import {List, Map} from 'immutable';
 import {firstValueFrom} from 'rxjs';
 
-import {Job} from 'app/models/job.model';
+import {DataCollectionStrategy, Job} from 'app/models/job.model';
 import {MultipleChoice} from 'app/models/task/multiple-choice.model';
 import {Option} from 'app/models/task/option.model';
+import {TaskCondition} from 'app/models/task/task-condition.model';
 import {Task, TaskType} from 'app/models/task/task.model';
 import {DataStoreService} from 'app/services/data-store/data-store.service';
 import {SurveyService} from 'app/services/survey/survey.service';
@@ -63,13 +64,14 @@ export class JobService {
    */
   createNewJob(): Job {
     const jobId = this.dataStoreService.generateId();
-    const task = this.createTask(TaskType.CAPTURE_LOCATION, '', true, 0);
+    const tasks = this.taskService.addLoiTask(Map());
     return new Job(
       jobId,
       /* index */ -1,
       undefined,
       undefined,
-      Map([[task.id, task]])
+      tasks,
+      DataCollectionStrategy.MIXED
     );
   }
 


### PR DESCRIPTION
closes #1667 - user can't click continue if free-form is set to off and there are no lois
closes #1797 - free-form box is now placed above the "import sites" one
closes #1798 - free-form toggle is automatically selected once a new job is created
closes #1987 - capture location is not anymore added by default