### PR TITLE
Refresh user profile on ID token change

### DIFF
--- a/web/src/app/services/auth/auth.service.spec.ts
+++ b/web/src/app/services/auth/auth.service.spec.ts
@@ -33,7 +33,13 @@ describe('AuthService', () => {
       providers: [
         {provide: AngularFirestore, useValue: {}},
         {provide: AngularFireFunctions, useValue: {}},
-        {provide: AngularFireAuth, useValue: {authState: NEVER}},
+        {
+          provide: AngularFireAuth,
+          useValue: {
+            authState: NEVER,
+            onIdTokenChanged: (callback: Function) => callback(null),
+          },
+        },
         {provide: DataStoreService, useValue: {user$: () => of()}},
         {provide: Router, useValue: {}},
         {provide: HttpClientService, useValue: {}},


### PR DESCRIPTION
Closes #1109 

Previously, we were only updating the user and user profile on sign-in / sign-out. This updates that logic to also make those updates on changes to the ID token.