### PR TITLE
Rfontanarosa/2180/loi panel clicking a submission forces the page to reload

### DIFF
--- a/web/src/app/pages/main-page-container/main-page-container.component.ts
+++ b/web/src/app/pages/main-page-container/main-page-container.component.ts
@@ -44,7 +44,9 @@ export class MainPageContainerComponent implements OnInit, OnDestroy {
     // Activate new survey on route changes.
     this.subscription.add(
       this.navigationService.getSurveyId$().subscribe(id => {
-        id && this.surveyService.activateSurvey(id);
+        if (!id) return;
+        if (this.surveyService.getActiveSurvey()?.id === id) return;
+        this.surveyService.activateSurvey(id);
       })
     );
   }

--- a/web/src/app/pages/main-page-container/main-page/map/map.component.ts
+++ b/web/src/app/pages/main-page-container/main-page/map/map.component.ts
@@ -137,11 +137,11 @@ export class MapComponent implements AfterViewInit, OnChanges, OnDestroy {
       combineLatest([
         this.activeSurvey$,
         this.lois$,
-        this.navigationService.getLocationOfInterestId$(),
+        this.loiService.getSelectedLocationOfInterest$(),
         this.navigationService.getTaskId$(),
         this.selectedJob$,
       ]).subscribe(
-        ([survey, lois, locationOfInterestId, taskId, selectedJob]) => {
+        ([survey, lois, {id: locationOfInterestId}, taskId, selectedJob]) => {
           const loisMap = this.getLoiMap(lois, selectedJob);
           const loiIdsToRemove = this.getLoiIdsToRemove(loisMap);
           const loisToAdd = this.getLoiIdsToAdd(loisMap);

--- a/web/src/app/pages/main-page-container/main-page/secondary-side-panel/loi-panel/loi-panel.component.html
+++ b/web/src/app/pages/main-page-container/main-page/secondary-side-panel/loi-panel/loi-panel.component.html
@@ -36,7 +36,7 @@ limitations under the License.
           data_info_alert
         </mat-icon>
       </button>
-      <button mat-icon-button aria-label="back" (click)="onClosePanel()">
+      <button mat-icon-button aria-label="back" (click)="closePanel()">
         <mat-icon>close</mat-icon>
       </button>
     </div>
@@ -52,12 +52,12 @@ limitations under the License.
       <div *ngFor="let submission of submissions; let i = index">
         <mat-divider *ngIf="i > 0"></mat-divider>
         <div class="submission-item">
-          <mat-list-item (click)="onSelectSubmission(submission.id)">
+          <mat-list-item (click)="selectSubmission(submission.id)">
             <mat-icon matListItemIcon class="material-symbols-outlined">text_snippet</mat-icon>
             <h3 matListItemTitle>{{ submission.created.user.displayName }}</h3>
             <p matListItemLine>{{ submission.created.clientTime | date: 'longDate' }}</p>
           </mat-list-item>
-          <button mat-icon-button (click)="onSelectSubmission(submission.id)">
+          <button mat-icon-button (click)="selectSubmission(submission.id)">
             <mat-icon>chevron_right</mat-icon>
           </button>
         </div>

--- a/web/src/app/pages/main-page-container/main-page/secondary-side-panel/loi-panel/loi-panel.component.ts
+++ b/web/src/app/pages/main-page-container/main-page/secondary-side-panel/loi-panel/loi-panel.component.ts
@@ -29,7 +29,7 @@ import {SurveyService} from 'app/services/survey/survey.service';
 import {getLoiIcon} from 'app/utils/utils';
 
 @Component({
-  selector: 'ground-loi-panel',
+  selector: 'loi-panel',
   templateUrl: './loi-panel.component.html',
   styleUrls: ['./loi-panel.component.scss'],
 })

--- a/web/src/app/pages/main-page-container/main-page/secondary-side-panel/loi-panel/loi-panel.component.ts
+++ b/web/src/app/pages/main-page-container/main-page/secondary-side-panel/loi-panel/loi-panel.component.ts
@@ -61,6 +61,7 @@ export class LocationOfInterestPanelComponent implements OnInit, OnDestroy {
             this.surveyId = survey.id;
             return this.loiService.getSelectedLocationOfInterest$().pipe(
               switchMap(loi => {
+                this.isLoading = true;
                 this.iconColor = survey.getJob(loi.jobId)!.color!;
                 this.loi = loi;
                 this.name = LocationOfInterestService.getDisplayName(loi);

--- a/web/src/app/pages/main-page-container/main-page/secondary-side-panel/loi-panel/loi-panel.component.ts
+++ b/web/src/app/pages/main-page-container/main-page/secondary-side-panel/loi-panel/loi-panel.component.ts
@@ -79,7 +79,7 @@ export class LocationOfInterestPanelComponent implements OnInit, OnDestroy {
     );
   }
 
-  onSelectSubmission(submissionId: string) {
+  selectSubmission(submissionId: string) {
     this.navigationService.showSubmissionDetail(
       this.surveyId,
       this.loi.id,
@@ -87,8 +87,8 @@ export class LocationOfInterestPanelComponent implements OnInit, OnDestroy {
     );
   }
 
-  onClosePanel() {
-    this.navigationService.clearLocationOfInterestId();
+  closePanel() {
+    this.navigationService.selectSurvey(this.surveyId);
   }
 
   hasProperties() {

--- a/web/src/app/pages/main-page-container/main-page/side-panel/side-panel.component.html
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/side-panel.component.html
@@ -14,8 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div [ngSwitch]="sideNavMode$ | async" class="side-panel">
-  <div *ngSwitchDefault>
+
     <ground-job-list></ground-job-list>
-  </div>
-</div>

--- a/web/src/app/pages/main-page-container/main-page/side-panel/side-panel.component.ts
+++ b/web/src/app/pages/main-page-container/main-page/side-panel/side-panel.component.ts
@@ -19,7 +19,7 @@ import {Observable} from 'rxjs';
 
 import {
   NavigationService,
-  SideNavMode,
+  // SideNavMode,
 } from 'app/services/navigation/navigation.service';
 
 @Component({
@@ -28,10 +28,10 @@ import {
   styleUrls: ['./side-panel.component.css'],
 })
 export class SidePanelComponent {
-  readonly sideNavMode = SideNavMode;
-  readonly sideNavMode$: Observable<SideNavMode>;
+  // readonly sideNavMode = SideNavMode;
+  // readonly sideNavMode$: Observable<SideNavMode>;
 
   constructor(private navigationService: NavigationService) {
-    this.sideNavMode$ = this.navigationService.getSideNavMode$();
+    // this.sideNavMode$ = this.navigationService.getSideNavMode$();
   }
 }

--- a/web/src/app/pages/survey-dashboard/survey-dashboard.component.html
+++ b/web/src/app/pages/survey-dashboard/survey-dashboard.component.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2023 The Ground Authors.
+  Copyright 2025 The Ground Authors.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -14,10 +14,20 @@
   limitations under the License.
 -->
 
-<div class="secondary-side-panel-container">
-  <div class="secondary-side-panel">
-    <submission-panel *ngIf="submissionId"></submission-panel>
+<div class="page">
+  <ground-survey-header></ground-survey-header>
 
-    <loi-panel *ngIf="!submissionId && locationOfInterestId"></loi-panel>
+  <div class="page-content" *ngIf="activeSurvey$ | async; else loading">
+    <ground-job-list></ground-job-list>
+
+    <router-outlet></router-outlet>
+
+    <ground-map [shouldEnableDrawingTools]="shouldEnableDrawingTools"></ground-map>
   </div>
 </div>
+
+<ng-template #loading>
+  <div class="progress-spinner">
+    <mat-spinner mode="indeterminate"></mat-spinner>
+  </div>
+</ng-template>

--- a/web/src/app/pages/survey-dashboard/survey-dashboard.component.scss
+++ b/web/src/app/pages/survey-dashboard/survey-dashboard.component.scss
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2019 The Ground Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.page {
+  min-height: 100%;
+  
+  .page-content {
+    display: flex;
+    height: calc(100vh - 80px);
+
+    ground-map {
+      width: 100%;
+    }
+  }
+}
+
+.sidenav-toggle {
+  top: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-width: unset;
+  right: -5px;
+  width: 5px;
+  height: 50px;
+  position: absolute;
+}

--- a/web/src/app/pages/survey-dashboard/survey-dashboard.component.ts
+++ b/web/src/app/pages/survey-dashboard/survey-dashboard.component.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2025 The Ground Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Component, OnDestroy, OnInit} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
+import {Observable, Subscription} from 'rxjs';
+
+import {Survey} from 'app/models/survey.model';
+import {AuthService} from 'app/services/auth/auth.service';
+import {NavigationService} from 'app/services/navigation/navigation.service';
+import {SurveyService} from 'app/services/survey/survey.service';
+import {environment} from 'environments/environment';
+
+@Component({
+  selector: 'ground-survey-dashboard',
+  templateUrl: './survey-dashboard.component.html',
+  styleUrls: ['./survey-dashboard.component.scss'],
+})
+export class SurveyDashboardComponent implements OnInit, OnDestroy {
+  activeSurvey$: Observable<Survey>;
+  private subscription = new Subscription();
+
+  constructor(
+    private authService: AuthService,
+    private navigationService: NavigationService,
+    private route: ActivatedRoute,
+    private surveyService: SurveyService
+  ) {
+    this.activeSurvey$ = surveyService.getActiveSurvey$();
+    navigationService.init(this.route);
+  }
+
+  ngOnInit() {
+    // Activate new survey on route changes.
+    this.subscription.add(
+      this.navigationService.getSurveyId$().subscribe(surveyId => {
+        if (!surveyId) return;
+        if (this.surveyService.getActiveSurvey()?.id === surveyId) return;
+        this.surveyService.activateSurvey(surveyId);
+      })
+    );
+
+    // Redirect to sign in page if user is not authenticated.
+    this.subscription.add(
+      this.authService.isAuthenticated$().subscribe(isAuthenticated => {
+        if (!isAuthenticated && !environment.useEmulators) {
+          this.navigationService.signIn();
+        }
+      })
+    );
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
+}

--- a/web/src/app/pages/survey-dashboard/survey-dashboard.module.ts
+++ b/web/src/app/pages/survey-dashboard/survey-dashboard.module.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2025 The Ground Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
+import {RouterModule} from '@angular/router';
+
+import {SurveyDashboardComponent} from './survey-dashboard.component';
+import {MapModule} from '../main-page-container/main-page/map/map.module';
+import {JobListModule} from '../main-page-container/main-page/side-panel/job-list/job-list.module';
+import {SidePanelModule} from '../main-page-container/main-page/side-panel/side-panel.module';
+import {SurveyHeaderModule} from '../main-page-container/main-page/survey-header/survey-header.module';
+
+@NgModule({
+  declarations: [SurveyDashboardComponent],
+  imports: [
+    CommonModule,
+    JobListModule,
+    MapModule,
+    MatProgressSpinnerModule,
+    RouterModule,
+    SidePanelModule,
+    SurveyHeaderModule,
+  ],
+  exports: [SurveyDashboardComponent],
+})
+export class SurveyDashboardModule {}

--- a/web/src/app/routing.module.ts
+++ b/web/src/app/routing.module.ts
@@ -23,8 +23,6 @@ import {SurveyListComponent} from 'app/components/survey-list/survey-list.compon
 import {SurveyListModule} from 'app/components/survey-list/survey-list.module';
 import {CreateSurveyComponent} from 'app/pages/create-survey/create-survey.component';
 import {CreateSurveyModule} from 'app/pages/create-survey/create-survey.module';
-import {MainPageContainerComponent} from 'app/pages/main-page-container/main-page-container.component';
-import {MainPageContainerModule} from 'app/pages/main-page-container/main-page-container.module';
 import {AuthGuard} from 'app/services/auth/auth.guard';
 import {NavigationService} from 'app/services/navigation/navigation.service';
 
@@ -37,6 +35,9 @@ import {EditSurveyModule} from './pages/edit-survey/edit-survey.module';
 import {SurveyJsonComponent} from './pages/edit-survey/survey-json/survey-json.component';
 import {ErrorComponent} from './pages/error/error.component';
 import {ErrorModule} from './pages/error/error.module';
+import {SecondarySidePanelComponent} from './pages/main-page-container/main-page/secondary-side-panel/secondary-side-panel.component';
+import {SurveyDashboardComponent} from './pages/survey-dashboard/survey-dashboard.component';
+import {SurveyDashboardModule} from './pages/survey-dashboard/survey-dashboard.module';
 import {TermsComponent} from './pages/terms/terms.component';
 
 const {
@@ -92,8 +93,22 @@ const routes: Routes = [
   },
   {
     path: `${NavigationService.SURVEY_SEGMENT}/:${SURVEY_ID}`,
-    component: MainPageContainerComponent,
+    component: SurveyDashboardComponent,
     canActivate: [AuthGuard],
+    children: [
+      {
+        path: `${LOI_SEGMENT}/:${LOI_ID}`,
+        component: SecondarySidePanelComponent,
+      },
+      {
+        path: `${LOI_SEGMENT}/:${LOI_ID}/${SUBMISSION_SEGMENT}/:${SUBMISSION_ID}`,
+        component: SecondarySidePanelComponent,
+      },
+      {
+        path: `${LOI_ID}/${SUBMISSION_SEGMENT}/:${SUBMISSION_ID}/${TASK_SEGMENT}/:${TASK_ID}`,
+        component: SecondarySidePanelComponent,
+      },
+    ],
   },
   {
     path: NavigationService.ERROR,
@@ -109,34 +124,19 @@ const routes: Routes = [
     component: TermsComponent,
     canActivate: [AuthGuard],
   },
-  {
-    path: `${NavigationService.SURVEY_SEGMENT}/:${SURVEY_ID}/${LOI_SEGMENT}/:${LOI_ID}`,
-    component: MainPageContainerComponent,
-    canActivate: [AuthGuard],
-  },
-  {
-    path: `${NavigationService.SURVEY_SEGMENT}/:${SURVEY_ID}/${LOI_SEGMENT}/:${LOI_ID}/${SUBMISSION_SEGMENT}/:${SUBMISSION_ID}`,
-    component: MainPageContainerComponent,
-    canActivate: [AuthGuard],
-  },
-  {
-    path: `${NavigationService.SURVEY_SEGMENT}/:${SURVEY_ID}/${LOI_SEGMENT}/:${LOI_ID}/${SUBMISSION_SEGMENT}/:${SUBMISSION_ID}/${TASK_SEGMENT}/:${TASK_ID}`,
-    component: MainPageContainerComponent,
-    canActivate: [AuthGuard],
-  },
 ];
 const config = RouterModule.forRoot(routes, {});
 
 @NgModule({
   imports: [config],
   exports: [
-    MainPageContainerModule,
-    RouterModule,
-    SignInPageModule,
-    SurveyListModule,
     CreateSurveyModule,
     EditSurveyModule,
     ErrorModule,
+    RouterModule,
+    SignInPageModule,
+    SurveyDashboardModule,
+    SurveyListModule,
   ],
 })
 export class AppRoutingModule {}

--- a/web/src/app/services/navigation/navigation.service.ts
+++ b/web/src/app/services/navigation/navigation.service.ts
@@ -14,14 +14,8 @@
  * limitations under the License.
  */
 
-import {HttpParams} from '@angular/common/http';
 import {Injectable} from '@angular/core';
-import {
-  ActivatedRoute,
-  IsActiveMatchOptions,
-  NavigationExtras,
-  Router,
-} from '@angular/router';
+import {ActivatedRoute, IsActiveMatchOptions, Router} from '@angular/router';
 import {Observable, of} from 'rxjs';
 import {map} from 'rxjs/operators';
 
@@ -55,33 +49,10 @@ export class NavigationService {
 
   private sidePanelExpanded = true;
 
-  private getSideNavMode(
-    loiId: string | null,
-    submissionId: string | null
-  ): SideNavMode {
-    if (submissionId) {
-      if (submissionId.includes('null')) {
-        this.error(new Error('Check your URL. Submission id was set to null'));
-      }
-      return SideNavMode.SUBMISSION;
-    }
-    if (loiId) {
-      if (loiId.includes('null')) {
-        this.error(
-          new Error('Check your URL. Location of interest id was set to null')
-        );
-      }
-      return SideNavMode.JOB_LIST;
-    }
-    return SideNavMode.JOB_LIST;
-  }
-
-  private activatedRoute?: ActivatedRoute;
   private surveyId$?: Observable<string | null>;
   private loiId$?: Observable<string | null>;
   private submissionId$?: Observable<string | null>;
   private taskId$?: Observable<string | null>;
-  private sideNavMode$?: Observable<SideNavMode>;
 
   constructor(private router: Router) {}
 
@@ -90,24 +61,13 @@ export class NavigationService {
    * the accessors are called.
    */
   init(route: ActivatedRoute) {
-    this.activatedRoute = route;
     // Pipe values from URL query parameters.
     this.surveyId$ = route.paramMap.pipe(map(params => params.get(SURVEY_ID)));
     this.loiId$ = route.paramMap.pipe(map(params => params.get(LOI_ID)));
-
     this.submissionId$ = route.paramMap.pipe(
       map(params => params.get(SUBMISSION_ID))
     );
-
     this.taskId$ = route.paramMap.pipe(map(params => params.get(TASK_ID)));
-
-    this.sideNavMode$ = route.paramMap.pipe(
-      map(params => {
-        const loiId = params.get(LOI_ID);
-        const submissionId = params.get(SUBMISSION_ID);
-        return this.getSideNavMode(loiId, submissionId);
-      })
-    );
   }
 
   getSurveyId$(): Observable<string | null> {
@@ -124,38 +84,6 @@ export class NavigationService {
 
   getTaskId$(): Observable<string | null> {
     return this.taskId$!;
-  }
-
-  getSideNavMode$(): Observable<SideNavMode> {
-    return this.sideNavMode$!;
-  }
-
-  /**
-   * Returns the current URL fragment, parsed as if their were normal HTTP
-   * query parameter key/value pairs.
-   */
-  private getFragmentParams(): HttpParams {
-    const fragment = this.activatedRoute!.snapshot.fragment;
-    return new HttpParams({fromString: fragment || ''});
-  }
-
-  /**
-   * Navigate to the current URL, replacing the URL fragment with the specified
-   * params.
-   */
-  private setFragmentParams(params: HttpParams) {
-    const primaryUrl = this.router
-      .parseUrl(this.router.url)
-      .root.children['primary'].toString();
-
-    if (params.toString()) {
-      const navigationExtras: NavigationExtras = {
-        fragment: params.toString(),
-      };
-      this.router.navigate([primaryUrl], navigationExtras);
-    } else {
-      this.router.navigate([primaryUrl]);
-    }
   }
 
   /**
@@ -297,11 +225,6 @@ export class NavigationService {
   onClickSidePanelButton() {
     this.sidePanelExpanded = !this.sidePanelExpanded;
   }
-}
-
-export enum SideNavMode {
-  JOB_LIST = 1,
-  SUBMISSION = 2,
 }
 
 const {


### PR DESCRIPTION
closes #2180
closes #2179
closes #2170
closes #2169

Introducing parameter-based URLs instead of query strings has caused some issues. Specifically, Angular treats these URLs as distinct, leading to the **reloading** of the MainPageContainerComponent. This behavior is the root cause of the issues listed above.

A potential solution involves listing the loi panel, submission panel, and task panel (currently unused) as children of the survey route.

Implementing this change would impact the NavigationService. Previously, it reacted to parameter changes, but it would no longer detect these changes at the MainPageComponent level.

This pull request represents a fully functional draft to evaluate the feasibility of this solution.


https://github.com/user-attachments/assets/9146f01e-3eeb-4c16-9129-7a932ca3ee8d

