### PR TITLE
Fixes Export CSV for LOIs missing the 'id' field

### DIFF
--- a/functions/src/common/datastore.ts
+++ b/functions/src/common/datastore.ts
@@ -204,7 +204,7 @@ export class Datastore {
     const submissionsIterator = new QueryIterator(submissionsQuery, pageSize);
     return leftOuterJoinSorted(
       loisIterator,
-      loiDoc => loiDoc.get(l.id),
+      loiDoc => loiDoc.id,
       submissionsIterator,
       submissionDoc => submissionDoc.get(sb.loiId)
     );


### PR DESCRIPTION
Some LOIs are saved without id field by the Android app. This can cause problem with the Export CSV. That problem has been partially fixed by https://github.com/google/ground-platform/pull/2187 but this small change will fix it completely.