### PR TITLE
Resolve broken share link generation

### DIFF
--- a/web/scripts/copy-asset-links.js
+++ b/web/scripts/copy-asset-links.js
@@ -30,7 +30,7 @@ if (existsSync(assertLinksFilepath)) {
     'utf8'
   );
 
-  const wellKnownDir = '../dist/.well-known';
+  const wellKnownDir = '../dist/web/.well-known';
 
   if (!existsSync(wellKnownDir)) {
     mkdirSync(wellKnownDir, { recursive: true });

--- a/web/src/app/components/copy-survey-controls/copy-survey-controls.component.html
+++ b/web/src/app/components/copy-survey-controls/copy-survey-controls.component.html
@@ -36,7 +36,7 @@
     [colorLight]="'#ffffffff'"
     [elementType]="'canvas'"
     [errorCorrectionLevel]="'M'"
-    [imageSrc]="'./assets/img/logo.svg'"
+    [imageSrc]="'/assets/img/logo.svg'"
     [imageHeight]="75"
     [imageWidth]="75"
     [margin]="2"

--- a/web/src/app/services/navigation/navigation.service.ts
+++ b/web/src/app/services/navigation/navigation.service.ts
@@ -299,12 +299,8 @@ export class NavigationService {
     return this.router.url.endsWith('/share');
   }
 
-  getBaseOriginUrl(): string {
-    return this.document.location.origin + this.location.prepareExternalUrl('');
-  }
-
   getSurveyAppLink(surveyId: string): string {
-    return this.getBaseOriginUrl() + `android/${SURVEY_SEGMENT}/${surveyId}`;
+    return `${this.document.location.origin}/android/${SURVEY_SEGMENT}/${surveyId}`;
   }
 
   getSidePanelExpanded(): boolean {


### PR DESCRIPTION
This fixes:

- Missing ground icon on the QR code.
- Incorrect share survey link (included language in the path).
- Missing .well-known folder (due to different deployment folder).