### PR TITLE
Prevent icon font text from flashing on first load

### DIFF
--- a/web/src/ground-theme.scss
+++ b/web/src/ground-theme.scss
@@ -105,6 +105,19 @@ html {
   @include terms.theme($theme);
 }
 
+// Prevent icon font ligature text from flashing before Material Icons fonts load.
+@font-face {
+  font-family: 'Material Icons';
+  font-style: normal;
+  font-display: block;
+}
+
+@font-face {
+  font-family: 'Material Symbols Outlined';
+  font-style: normal;
+  font-display: block;
+}
+
 // Global styles
 html,
 body {


### PR DESCRIPTION
closes #1588

Add @font-face overrides in ground-theme.scss for both Material Icons and Material Symbols Outlined with font-display: block. This causes the browser to render the icon text as invisible rather than as plain text while the font loads, so icons simply appear once the font is ready with no flash.