### PR TITLE
Drop legacy mat-select panel-width CSS in favor of MAT_SELECT_CONFIG

### DIFF
--- a/web/src/app/app.module.ts
+++ b/web/src/app/app.module.ts
@@ -20,6 +20,7 @@ import {
 } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { MatIconRegistry } from '@angular/material/icon';
+import { MAT_SELECT_CONFIG } from '@angular/material/select';
 import { initializeApp, provideFirebaseApp } from '@angular/fire/app';
 import { getAuth, provideAuth } from '@angular/fire/auth';
 import {
@@ -100,6 +101,7 @@ import { environment } from 'environments/environment';
     }),
 
     provideHttpClient(withInterceptorsFromDi()),
+    {provide: MAT_SELECT_CONFIG, useValue: {panelWidth: null}},
   ],
 })
 export class AppModule {

--- a/web/src/ground-theme.scss
+++ b/web/src/ground-theme.scss
@@ -147,14 +147,6 @@ snack-bar-container.notification {
   max-width: 340px !important;
 }
 
-// TODO(#1633): Can remove once upgraded past v16.1, there is a panelWidth
-// input property for mat-select that can be set to null. By default
-// options are set to the select trigger width, but can be set to the
-// longest option width instead.
-.cdk-overlay-pane:has(.mat-mdc-select-panel) {
-  min-width: fit-content;
-}
-
 .mat-mdc-select-arrow-wrapper{
   padding-left: 12px;
 }


### PR DESCRIPTION
closes #1633