### PR TITLE
Fix Firebase i18n root and add jasmine to TS types

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -6,7 +6,7 @@
   "hosting": {
     "public": "web/dist/web",
     "i18n": {
-      "root": "web/dist/web"
+      "root": "/"
     },
     "redirects": [
       {

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -17,7 +17,7 @@
     "experimentalDecorators": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "types": ["node"],
+    "types": ["node", "jasmine"],
     "moduleResolution": "bundler"
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
- `firebase.json`: change hosting `i18n.root` from `web/dist/web` to `/`. The `root` is a URL path prefix served by Firebase Hosting (relative to `public`), not a filesystem path — pointing it at the build output directory was incorrect and prevented i18n routing from working.
- `web/tsconfig.json`: add `jasmine` to `compilerOptions.types` so test globals (`describe`, `it`, `expect`, …) type-check without ambient declaration errors in spec files.