### PR TITLE
Fix AttributeError in offline imagery notebook (ee.data._credentials)

### DIFF
--- a/notebooks/generate_offline_imagery1.ipynb
+++ b/notebooks/generate_offline_imagery1.ipynb
@@ -216,8 +216,10 @@
       "cell_type": "code",
       "source": [
         "import ee\n",
+        "import google.auth\n",
+        "credentials, _ = google.auth.default()\n",
         "ee.Authenticate()\n",
-        "ee.Initialize(project=CLOUD_PROJECT)"
+        "ee.Initialize(credentials=credentials, project=CLOUD_PROJECT)"
       ],
       "metadata": {
         "id": "tZ75jyTNWVZ0"
@@ -569,7 +571,7 @@
         "# OVERWRITE_EXISTING=True\n",
         "\n",
         "# Access dest bucket to check if files already exist.\n",
-        "storage_client = storage.Client(credentials=ee.data._credentials)\n",
+        "storage_client = storage.Client(credentials=credentials)\n",
         "bucket = storage_client.bucket(DEST_BUCKET)\n",
         "\n",
         "# https://google-auth-oauthlib.readthedocs.io/en/latest/reference/google_auth_oauthlib.flow.html\n",


### PR DESCRIPTION
Obtain credentials via the documented public API (`google.auth.default()`) and pass them explicitly to both `ee.Initialize()` and `storage.Client()`.