### PR TITLE
 PNPM config migration

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: Install pnpm
       uses: pnpm/action-setup@v4
       with:
-        version: 9
+        version: 10.30.3
 
     - name: Set up Node.js
       uses: actions/setup-node@v6

--- a/functions/package.json
+++ b/functions/package.json
@@ -98,7 +98,8 @@
     "sanitize-html": "catalog:"
   },
   "engines": {
-    "node": "22"
+    "node": "22",
+    "pnpm": "10.30.3"
   },
   "private": true,
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -149,25 +149,6 @@
   "engines": {
     "node": "22"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@bufbuild/buf",
-      "@firebase/util",
-      "@parcel/watcher",
-      "core-js",
-      "esbuild",
-      "farmhash",
-      "fsevents",
-      "less",
-      "lmdb",
-      "msgpackr-extract",
-      "nx",
-      "protobufjs",
-      "puppeteer",
-      "re2",
-      "unrs-resolver"
-    ]
-  },
   "optionalDependencies": {
     "@nx/nx-linux-x64-gnu": "^19.3.2"
   }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,23 @@ packages:
   - proto
   - web
 
+onlyBuiltDependencies:
+  - '@bufbuild/buf'
+  - '@firebase/util'
+  - '@parcel/watcher'
+  - core-js
+  - esbuild
+  - farmhash
+  - fsevents
+  - less
+  - lmdb
+  - msgpackr-extract
+  - nx
+  - protobufjs
+  - puppeteer
+  - re2
+  - unrs-resolver
+
 catalogs:
   default:
     '@angular/animations': ^20.3.15


### PR DESCRIPTION
Relocates onlyBuiltDependencies from the root package.json pnpm field into pnpm-workspace.yaml (alongside the existing catalogs) and pins pnpm to 10.30.3. The allowlist is unchanged; this aligns with pnpm's consolidation of settings into the workspace file — required since pnpm v11 no longer reads the pnpm field from package.json.