### PR TITLE
Rename "Unlisted" survey access to "Anyone with the link"

### DIFF
--- a/web/src/app/components/create-survey/create-survey.component.html
+++ b/web/src/app/components/create-survey/create-survey.component.html
@@ -114,11 +114,6 @@
       </div>
 
       <div class="right-button-section">
-        <ground-copy-survey-controls
-          *ngIf="createSurveyPhase === CreateSurveyPhase.SHARE_SURVEY"
-          [surveyId]="surveyId"
-        ></ground-copy-survey-controls>
-
         <button
           id="continue-button"
           class="continue-button"

--- a/web/src/app/components/create-survey/create-survey.module.ts
+++ b/web/src/app/components/create-survey/create-survey.module.ts
@@ -24,7 +24,6 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { CreateSurveyComponent } from 'app/components/create-survey/create-survey.component';
 import { DataSharingTermsModule } from 'app/components/create-survey/data-sharing-terms/data-sharing-terms.module';
 import { TaskDetailsModule } from 'app/components/create-survey/task-details/task-details.module';
-import { CopySurveyControlsModule } from 'app/components/shared/copy-survey-controls/copy-survey-controls.module';
 import { HeaderModule } from 'app/components/shared/header/header.module';
 import { ShareSurveyModule } from 'app/components/shared/share-survey/share-survey.module';
 
@@ -44,7 +43,6 @@ import { SurveyLoiModule } from './survey-loi/survey-loi.module';
     MatInputModule,
     MatProgressBarModule,
     MatProgressSpinnerModule,
-    CopySurveyControlsModule,
     ShareSurveyModule,
     StepCardModule,
     SurveyDetailsModule,

--- a/web/src/app/components/edit-survey/edit-survey.component.html
+++ b/web/src/app/components/edit-survey/edit-survey.component.html
@@ -139,15 +139,6 @@
         </h1>
 
         <router-outlet></router-outlet>
-
-        <div
-          class="button-section"
-          *ngIf="navigationService.isShareSurveyPage()"
-        >
-          <ground-copy-survey-controls
-            [surveyId]="surveyId() || ''"
-          ></ground-copy-survey-controls>
-        </div>
       </div>
     </div>
   </div>

--- a/web/src/app/components/edit-survey/edit-survey.module.ts
+++ b/web/src/app/components/edit-survey/edit-survey.module.ts
@@ -26,7 +26,6 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { RouterModule } from '@angular/router';
 
 import { EditSurveyComponent } from 'app/components/edit-survey/edit-survey.component';
-import { CopySurveyControlsModule } from 'app/components/shared/copy-survey-controls/copy-survey-controls.module';
 
 import { SurveyHeaderModule } from '../main-page/survey-header/survey-header.module';
 
@@ -42,7 +41,6 @@ import { SurveyHeaderModule } from '../main-page/survey-header/survey-header.mod
     MatMenuModule,
     MatProgressSpinnerModule,
     RouterModule,
-    CopySurveyControlsModule,
     SurveyHeaderModule,
   ],
   exports: [EditSurveyComponent],

--- a/web/src/app/components/shared/general-access-control/general-access-control.component.html
+++ b/web/src/app/components/shared/general-access-control/general-access-control.component.html
@@ -41,4 +41,9 @@
       {{generalAccessLabels.get(selectedGeneralAccess)?.description}}
     </div>
   </div>
+
+  <ground-copy-survey-controls
+    *ngIf="selectedGeneralAccess === SurveyGeneralAccess.UNLISTED"
+    [surveyId]="survey()?.id || ''"
+  ></ground-copy-survey-controls>
 </div>

--- a/web/src/app/components/shared/general-access-control/general-access-control.component.scss
+++ b/web/src/app/components/shared/general-access-control/general-access-control.component.scss
@@ -37,4 +37,8 @@
       width: fit-content;
     }
   }
+
+  ground-copy-survey-controls {
+    margin-left: auto;
+  }
 }

--- a/web/src/app/components/shared/general-access-control/general-access-control.component.ts
+++ b/web/src/app/components/shared/general-access-control/general-access-control.component.ts
@@ -40,7 +40,7 @@ const generalAccessLabels = Map<
     {
       description: $localize`:@@app.texts.generalAccess.unlisted:Everyone with the survey QR code or link can collect data for this survey`,
       icon: 'account_circle',
-      label: $localize`:@@app.labels.unlisted:Unlisted`,
+      label: $localize`:@@app.labels.unlisted:Anyone with the link`,
     },
   ],
   [

--- a/web/src/app/components/shared/general-access-control/general-access-control.module.ts
+++ b/web/src/app/components/shared/general-access-control/general-access-control.module.ts
@@ -25,12 +25,15 @@ import { MatInputModule } from '@angular/material/input';
 import { MatListModule } from '@angular/material/list';
 import { MatSelectModule } from '@angular/material/select';
 
+import { CopySurveyControlsModule } from 'app/components/shared/copy-survey-controls/copy-survey-controls.module';
+
 import { GeneralAccessControlComponent } from './general-access-control.component';
 
 @NgModule({
   declarations: [GeneralAccessControlComponent],
   imports: [
     CommonModule,
+    CopySurveyControlsModule,
     FormsModule,
     MatButtonModule,
     MatDialogModule,

--- a/web/src/app/components/shared/survey-list/survey-list.component.html
+++ b/web/src/app/components/shared/survey-list/survey-list.component.html
@@ -128,7 +128,7 @@
     <span
       *ngIf="filter === SurveyListFilter.UNLISTED"
       i18n="@@app.labels.unlisted"
-      >Unlisted</span
+      >Anyone with the link</span
     >
     <span *ngIf="filter === SurveyListFilter.PUBLIC" i18n="@@app.labels.public"
       >Public</span

--- a/web/src/locale/messages.json
+++ b/web/src/locale/messages.json
@@ -107,7 +107,7 @@
     "app.texts.generalAccess.restricted": "Only people with access can open with the link",
     "app.labels.restricted": "Restricted",
     "app.texts.generalAccess.unlisted": "Everyone with the survey QR code or link can collect data for this survey",
-    "app.labels.unlisted": "Unlisted",
+    "app.labels.unlisted": "Anyone with the link",
     "app.texts.generalAccess.public": "Anyone can find and collect data for this survey",
     "app.labels.public": "Public",
     "app.labels.signOut": "Sign out",


### PR DESCRIPTION
closes #2507

<img width="1209" height="426" alt="Screenshot 2026-07-09 alle 09 36 55" src="https://github.com/user-attachments/assets/1cd16b3c-1c98-4691-b998-d1a842fe72f8" />

<img width="1087" height="163" alt="Screenshot 2026-07-09 alle 09 41 12" src="https://github.com/user-attachments/assets/68daff14-1f75-44aa-90d6-9ac87a8c596b" />


Are the three access levels really peers? "Restricted" and "Anyone with the link" both describe unlisted surveys — they differ only in who can open the link/QR (named people vs. anyone).

"Public" is a different dimension entirely: discoverability (the survey can be found without a link at all).

Given that, should the filter keep treating them as three flat siblings, or model it as listed vs. unlisted with link/QR access as a sub-option of the unlisted case?

This mainly affects how we label and group the survey-list filter chips.

wdyt? @gino-m @jo-spek 