### PR TITLE
 Keep the edit header sticky with a solid background

### DIFF
--- a/web/src/app/components/edit-survey/_edit-survey.component-theme.scss
+++ b/web/src/app/components/edit-survey/_edit-survey.component-theme.scss
@@ -18,6 +18,10 @@
  @use '@angular/material' as mat;
 
  @mixin color($theme) {
+  .page > ground-survey-header {
+    background-color: mat.get-theme-color($theme, neutral, 94);
+  }
+
   .edit-survey-title {
     color: mat.get-theme-color($theme, on-background);
   }

--- a/web/src/app/components/edit-survey/edit-survey.component.scss
+++ b/web/src/app/components/edit-survey/edit-survey.component.scss
@@ -16,6 +16,13 @@
 
 .page {
   min-height: 100%;
+
+  > ground-survey-header {
+    display: block;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+  }
 }
 
 .loading-spinner {


### PR DESCRIPTION
closes #2514 

<img width="1584" height="462" alt="Screenshot 2026-07-16 alle 13 53 54" src="https://github.com/user-attachments/assets/36279bc2-4f57-4170-a8d6-9aa14a371976" />
