### PR TITLE
Implement polygon drawing for web app

### DIFF
--- a/web/src/app/components/main-page/drawing-tools/drawing-tools.component.html
+++ b/web/src/app/components/main-page/drawing-tools/drawing-tools.component.html
@@ -30,11 +30,14 @@
     <img id="add-point-icon" class="add-point-icon" [src]="addPointIcon" />
   </mat-button-toggle>
   <mat-button-toggle
-    hidden
+    *ngIf="!jobs().isEmpty()"
+    id="add-polygon-button"
+    class="add-polygon-button"
     value="{{ polygonValue }}"
     (click)="onButtonClick()"
+    matTooltip="Draw polygon"
   >
-    add polygon
+    <mat-icon>pentagon</mat-icon>
   </mat-button-toggle>
 </mat-button-toggle-group>
 

--- a/web/src/app/components/main-page/drawing-tools/drawing-tools.module.ts
+++ b/web/src/app/components/main-page/drawing-tools/drawing-tools.module.ts
@@ -22,6 +22,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSelectModule } from '@angular/material/select';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { DrawingToolsComponent } from './drawing-tools.component';
 
@@ -34,6 +35,7 @@ import { DrawingToolsComponent } from './drawing-tools.component';
     MatExpansionModule,
     MatFormFieldModule,
     MatSelectModule,
+    MatTooltipModule,
   ],
   exports: [DrawingToolsComponent],
   declarations: [DrawingToolsComponent],

--- a/web/src/app/components/main-page/map/map.component.html
+++ b/web/src/app/components/main-page/map/map.component.html
@@ -22,6 +22,37 @@ limitations under the License.
 >
 </google-map>
 
+<!-- Polygon drawing toolbar -->
+<div
+  *ngIf="shouldEnableDrawingTools && isDrawingPolygon"
+  id="polygon-draw-dialog"
+  class="polygon-draw-dialog"
+>
+  <div class="dialog-content">
+    <div class="dialog-text">
+      {{ drawingVertices.length < 3 ? 'Click map to add vertices' : 'Add more vertices or complete' }}
+    </div>
+    <button
+      class="dialog-button"
+      id="cancel-polygon"
+      mat-flat-button
+      (click)="onCancelPolygon()"
+    >
+      <label>Cancel</label>
+    </button>
+    <button
+      class="dialog-button"
+      id="complete-polygon"
+      mat-flat-button
+      color="primary"
+      [disabled]="drawingVertices.length < 3"
+      (click)="onCompletePolygon()"
+    >
+      <label>Complete</label>
+    </button>
+  </div>
+</div>
+
 <div
   *ngIf="shouldEnableDrawingTools && showRepositionConfirmDialog"
   id="reposition-confirm-dialog"

--- a/web/src/app/components/main-page/map/map.component.scss
+++ b/web/src/app/components/main-page/map/map.component.scss
@@ -14,6 +14,19 @@
  * limitations under the License.
  */
 
+.polygon-draw-dialog {
+  position: absolute;
+  bottom: 2em;
+  left: 50%;
+  transform: translate(-50%, 0);
+  width: 440px;
+  height: 66px;
+  border-radius: 8px;
+  background: white;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  z-index: 10;
+}
+
 .reposition-confirm-dialog {
   position: absolute;
   bottom: 2em;

--- a/web/src/app/components/main-page/map/map.component.spec.ts
+++ b/web/src/app/components/main-page/map/map.component.spec.ts
@@ -160,7 +160,7 @@ describe('MapComponent', () => {
   beforeEach(async () => {
     loiServiceSpy = jasmine.createSpyObj<LocationOfInterestService>(
       'LocationOfInterestService',
-      ['updatePoint', 'addPoint']
+      ['updatePoint', 'addPoint', 'addPolygon']
     );
 
     mockLois$ = new BehaviorSubject<List<LocationOfInterest>>(
@@ -661,7 +661,7 @@ describe('MapComponent', () => {
       latLng: new google.maps.LatLng(45, 45),
     });
 
-    expect(loiServiceSpy.addPoint).toHaveBeenCalledOnceWith(45, 45, jobId2);
+    expect(loiServiceSpy.addPoint).toHaveBeenCalledOnceWith(45, 45, jobId2, surveyId);
   });
 
   it('should not add marker when job id is undefined', async () => {
@@ -677,8 +677,9 @@ describe('MapComponent', () => {
     expect(loiServiceSpy.addPoint).toHaveBeenCalledTimes(0);
   });
 
-  it('should do nothing when map clicked and edit mode is "AddPolygon"', async () => {
+  it('should collect a vertex when map clicked and edit mode is "AddPolygon"', async () => {
     mockEditMode$.next(EditMode.AddPolygon);
+    drawingToolsServiceSpy.getSelectedJobId.and.returnValue(jobId2);
     fixture.detectChanges();
     await fixture.whenStable();
 
@@ -687,6 +688,48 @@ describe('MapComponent', () => {
     });
 
     expect(loiServiceSpy.addPoint).toHaveBeenCalledTimes(0);
+    expect(component.drawingVertices.length).toBe(1);
+    expect(component.isDrawingPolygon).toBeTrue();
+  });
+
+  it('should save polygon and reset state when onCompletePolygon is called with 3+ vertices', async () => {
+    const newPolygonLoi = new LocationOfInterest(
+      'newPolyId',
+      jobId2,
+      polygonLoi1.geometry,
+      Map()
+    );
+    loiServiceSpy.addPolygon.and.returnValue(
+      new Promise(resolve => resolve(newPolygonLoi))
+    );
+    mockEditMode$.next(EditMode.AddPolygon);
+    drawingToolsServiceSpy.getSelectedJobId.and.returnValue(jobId2);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // Simulate 3 clicks to collect vertices.
+    for (const [lat, lng] of [[1, 1], [2, 2], [3, 1]] as [number, number][]) {
+      google.maps.event.trigger(component.map.googleMap!, 'click', {
+        latLng: new google.maps.LatLng(lat, lng),
+      });
+    }
+    expect(component.drawingVertices.length).toBe(3);
+
+    await component.onCompletePolygon();
+
+    expect(loiServiceSpy.addPolygon).toHaveBeenCalledOnceWith(
+      jasmine.arrayWithExactContents([
+        new google.maps.LatLng(1, 1),
+        new google.maps.LatLng(2, 2),
+        new google.maps.LatLng(3, 1),
+      ]),
+      jobId2,
+      surveyId
+    );
+    expect(component.isDrawingPolygon).toBeFalse();
+    expect(component.drawingVertices.length).toBe(0);
+    expect(navigationServiceSpy.selectLocationOfInterest)
+      .toHaveBeenCalledOnceWith(surveyId, newPolygonLoi.id);
   });
 
   function assertMarkerLatLng(

--- a/web/src/app/components/main-page/map/map.component.ts
+++ b/web/src/app/components/main-page/map/map.component.ts
@@ -116,6 +116,12 @@ export class MapComponent implements AfterViewInit, OnChanges, OnDestroy {
   submission: Submission | null = null;
   showSubmissionGeometry = false;
 
+  // ── Polygon drawing state ──────────────────────────────────────────────────
+  isDrawingPolygon = false;
+  drawingVertices: google.maps.LatLng[] = [];
+  private drawingPolygonOverlay: google.maps.Polygon | null = null;
+  private drawingVertexMarkers: google.maps.marker.AdvancedMarkerElement[] = [];
+
   readonly DEFAULT_MARKER_COLOR = 'black';
 
   @ViewChild(GoogleMap) map!: GoogleMap;
@@ -350,7 +356,8 @@ export class MapComponent implements AfterViewInit, OnChanges, OnDestroy {
         const newLocationOfInterest = await this.loiService.addPoint(
           event.latLng!.lat(),
           event.latLng!.lng(),
-          selectedJobId
+          selectedJobId,
+          this.lastFitSurveyId
         );
         if (newLocationOfInterest) {
           this.navigationService.selectLocationOfInterest(
@@ -360,9 +367,16 @@ export class MapComponent implements AfterViewInit, OnChanges, OnDestroy {
         }
         return;
       }
-      case EditMode.AddPolygon:
-        // TODO: Implement adding polygon.
+      case EditMode.AddPolygon: {
+        if (!selectedJobId) return;
+        const latLng = event.latLng!;
+        this.drawingVertices.push(latLng);
+        this.isDrawingPolygon = true;
+        this.addDrawingVertexMarker(latLng);
+        this.updateDrawingPolygonOverlay();
+        this.changeDetectorRef.detectChanges();
         return;
+      }
       case EditMode.None:
       default:
         this.navigationService.clearLocationOfInterestId();
@@ -615,6 +629,10 @@ export class MapComponent implements AfterViewInit, OnChanges, OnDestroy {
   }
 
   private onEditModeChange(editMode: EditMode) {
+    // Clear polygon drawing state whenever we leave AddPolygon mode.
+    if (editMode !== EditMode.AddPolygon) {
+      this.clearDrawingState();
+    }
     if (editMode !== EditMode.None) {
       this.navigationService.clearLocationOfInterestId();
       for (const marker of this.markers) {
@@ -625,10 +643,99 @@ export class MapComponent implements AfterViewInit, OnChanges, OnDestroy {
         marker[1].gmpClickable = true;
       }
     }
+    // Use crosshair cursor for both point and polygon drawing modes.
     this.mapOptions =
-      editMode === EditMode.AddPoint
+      editMode === EditMode.AddPoint || editMode === EditMode.AddPolygon
         ? this.crosshairCursorMapOptions
         : this.defaultCursorMapOptions;
+  }
+
+  // ── Polygon drawing helpers ────────────────────────────────────────────────
+
+  /**
+   * Adds a small dot marker at the given vertex position to give the user
+   * visual feedback about each clicked point.
+   */
+  private addDrawingVertexMarker(latLng: google.maps.LatLng) {
+    const dot = document.createElement('div');
+    dot.style.cssText =
+      'width:10px;height:10px;background:#1a73e8;border-radius:50%;' +
+      'border:2px solid white;box-shadow:0 1px 3px rgba(0,0,0,.4);';
+    const marker = new google.maps.marker.AdvancedMarkerElement({
+      map: this.map.googleMap,
+      position: latLng,
+      content: dot,
+      gmpClickable: false,
+    });
+    this.drawingVertexMarkers.push(marker);
+  }
+
+  /**
+   * Redraws the semi-transparent polygon preview that follows the cursor
+   * as the user adds vertices.
+   */
+  private updateDrawingPolygonOverlay() {
+    if (this.drawingPolygonOverlay) {
+      this.drawingPolygonOverlay.setMap(null);
+      this.drawingPolygonOverlay = null;
+    }
+    if (this.drawingVertices.length < 2) return;
+    this.drawingPolygonOverlay = new google.maps.Polygon({
+      paths: this.drawingVertices,
+      strokeColor: '#1a73e8',
+      strokeOpacity: 0.9,
+      strokeWeight: 2,
+      fillColor: '#1a73e8',
+      fillOpacity: 0.15,
+      map: this.map.googleMap,
+      clickable: false,
+    });
+  }
+
+  /** Removes all temporary drawing overlays and resets drawing state. */
+  private clearDrawingState() {
+    for (const m of this.drawingVertexMarkers) {
+      m.map = null;
+    }
+    this.drawingVertexMarkers = [];
+    if (this.drawingPolygonOverlay) {
+      this.drawingPolygonOverlay.setMap(null);
+      this.drawingPolygonOverlay = null;
+    }
+    this.drawingVertices = [];
+    this.isDrawingPolygon = false;
+  }
+
+  /**
+   * Called when the user clicks "Complete" in the polygon drawing toolbar.
+   * Saves the polygon as a new LOI and resets drawing mode.
+   */
+  async onCompletePolygon() {
+    if (this.drawingVertices.length < 3) return;
+    const selectedJobId = this.drawingToolsService.getSelectedJobId();
+    if (!selectedJobId) return;
+
+    const vertices = [...this.drawingVertices];
+    this.clearDrawingState();
+    this.drawingToolsService.setEditMode(EditMode.None);
+
+    const newLoi = await this.loiService.addPolygon(
+      vertices,
+      selectedJobId,
+      this.lastFitSurveyId
+    );
+    if (newLoi) {
+      this.navigationService.selectLocationOfInterest(
+        this.lastFitSurveyId,
+        newLoi.id
+      );
+    }
+  }
+
+  /** Called when the user clicks "Cancel" during polygon drawing. */
+  onCancelPolygon() {
+    this.clearDrawingState();
+    this.drawingToolsService.setEditMode(EditMode.None);
   }
 
   /**

--- a/web/src/app/converters/geometry-data-converter.ts
+++ b/web/src/app/converters/geometry-data-converter.ts
@@ -26,6 +26,54 @@ import { Polygon } from 'app/models/geometry/polygon';
 
 import Pb = GroundProtos.ground.v1beta1;
 
+// ── Model → Protobuf ──────────────────────────────────────────────────────────
+
+export function geometryModelToPb(geometry: Geometry): Pb.IGeometry {
+  if (geometry instanceof Point) {
+    return new Pb.Geometry({point: pointModelToPb(geometry)});
+  } else if (geometry instanceof Polygon) {
+    return new Pb.Geometry({polygon: polygonModelToPb(geometry)});
+  } else if (geometry instanceof MultiPolygon) {
+    return new Pb.Geometry({multiPolygon: multiPolygonModelToPb(geometry)});
+  } else {
+    throw new Error('Unsupported geometry type');
+  }
+}
+
+function pointModelToPb(point: Point): Pb.IPoint {
+  return new Pb.Point({
+    coordinates: coordinateModelToPb(point.coord),
+  });
+}
+
+function polygonModelToPb(polygon: Polygon): Pb.IPolygon {
+  return new Pb.Polygon({
+    shell: linearRingModelToPb(polygon.shell),
+    holes: polygon.holes.map(h => linearRingModelToPb(h)).toArray(),
+  });
+}
+
+function multiPolygonModelToPb(mp: MultiPolygon): Pb.IMultiPolygon {
+  return new Pb.MultiPolygon({
+    polygons: mp.polygons.map(p => polygonModelToPb(p)).toArray(),
+  });
+}
+
+function linearRingModelToPb(ring: LinearRing): Pb.ILinearRing {
+  return new Pb.LinearRing({
+    coordinates: ring.points.map(c => coordinateModelToPb(c)).toArray(),
+  });
+}
+
+function coordinateModelToPb(coord: Coordinate): Pb.ICoordinates {
+  return new Pb.Coordinates({
+    longitude: coord.x,
+    latitude: coord.y,
+  });
+}
+
+// ── Protobuf → Model ──────────────────────────────────────────────────────────
+
 export function geometryPbToModel(pb: Pb.IGeometry): Geometry {
   if (pb.point) {
     return pointPbToModel(pb.point);

--- a/web/src/app/converters/loi-data-converter.ts
+++ b/web/src/app/converters/loi-data-converter.ts
@@ -15,14 +15,14 @@
  */
 
 import { DocumentData } from '@angular/fire/firestore';
-import { toMessage } from '@ground/lib';
+import { toDocumentData, toMessage } from '@ground/lib';
 
 import { GroundProtos } from '@ground/proto';
 import { Map } from 'immutable';
 
 import { LocationOfInterest } from 'app/models/loi.model';
 
-import { geometryPbToModel } from './geometry-data-converter';
+import { geometryModelToPb, geometryPbToModel } from './geometry-data-converter';
 
 import Pb = GroundProtos.ground.v1beta1;
 
@@ -37,6 +37,23 @@ function propertiesPbToModel(pb: {
     }
   }
   return Map(Object.entries(properties));
+}
+
+/**
+ * Converts a LocationOfInterest model object to a Firestore document.
+ */
+export function loiToDocument(loi: LocationOfInterest): DocumentData {
+  return toDocumentData(
+    new Pb.LocationOfInterest({
+      jobId: loi.jobId,
+      geometry: geometryModelToPb(loi.geometry),
+      source: loi.predefined
+        ? Pb.LocationOfInterest.Source.IMPORTED
+        : Pb.LocationOfInterest.Source.FIELD_DATA,
+      customTag: loi.customId,
+      submissionCount: loi.submissionCount,
+    })
+  );
 }
 
 export function loiDocToModel(

--- a/web/src/app/services/data-store/data-store.service.ts
+++ b/web/src/app/services/data-store/data-store.service.ts
@@ -43,7 +43,7 @@ import { Observable, combineLatest, from } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { FirebaseDataConverter } from 'app/converters/firebase-data-converter';
-import { loiDocToModel } from 'app/converters/loi-data-converter';
+import { loiDocToModel, loiToDocument } from 'app/converters/loi-data-converter';
 import {
   jobToDocument,
   surveyToDocument,
@@ -419,6 +419,24 @@ export class DataStoreService {
     await Promise.all(
       querySnapshot.docs.map(doc =>
         runInInjectionContext(this.injector, () => deleteDoc(doc.ref))
+      )
+    );
+  }
+
+  /**
+   * Adds or updates a Location of Interest in Firestore.
+   *
+   * @param surveyId The ID of the survey the LOI belongs to.
+   * @param loi The LocationOfInterest model to save.
+   */
+  async addOrUpdateLoi(
+    surveyId: string,
+    loi: LocationOfInterest
+  ): Promise<void> {
+    return runInInjectionContext(this.injector, () =>
+      setDoc(
+        doc(this.db, `${SURVEYS_COLLECTION_NAME}/${surveyId}/lois`, loi.id),
+        loiToDocument(loi)
       )
     );
   }

--- a/web/src/app/services/loi/loi.service.ts
+++ b/web/src/app/services/loi/loi.service.ts
@@ -15,11 +15,15 @@
  */
 
 import { Injectable } from '@angular/core';
-import { List } from 'immutable';
+import { List, Map } from 'immutable';
 import { Observable, of } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 
+import { Coordinate } from 'app/models/geometry/coordinate';
 import { GeometryType } from 'app/models/geometry/geometry';
+import { LinearRing } from 'app/models/geometry/linear-ring';
+import { Point } from 'app/models/geometry/point';
+import { Polygon } from 'app/models/geometry/polygon';
 import { LocationOfInterest } from 'app/models/loi.model';
 import {
   Survey,
@@ -133,12 +137,57 @@ export class LocationOfInterestService {
     return bounds;
   }
 
+  /**
+   * Adds a new point LOI to Firestore for the given survey and job.
+   */
   async addPoint(
-    _lat: number,
-    _lng: number,
-    _jobId: string
+    lat: number,
+    lng: number,
+    jobId: string,
+    surveyId: string
   ): Promise<LocationOfInterest | null> {
-    throw new Error('Adding LOIs via web app not yet supported');
+    const id = this.dataStore.generateId();
+    const loi = new LocationOfInterest(
+      id,
+      jobId,
+      new Point(new Coordinate(lng, lat)),
+      Map<string, string | number>(),
+      /* customId= */ '',
+      /* predefined= */ false,
+      /* submissionCount= */ 0
+    );
+    await this.dataStore.addOrUpdateLoi(surveyId, loi);
+    return loi;
+  }
+
+  /**
+   * Adds a new polygon LOI to Firestore for the given survey and job.
+   * @param vertices Ordered list of LatLng vertices (the ring is closed automatically).
+   */
+  async addPolygon(
+    vertices: google.maps.LatLng[],
+    jobId: string,
+    surveyId: string
+  ): Promise<LocationOfInterest | null> {
+    if (vertices.length < 3) return null;
+    const id = this.dataStore.generateId();
+    // Close the ring by repeating the first vertex at the end.
+    const coords = [...vertices, vertices[0]].map(
+      v => new Coordinate(v.lng(), v.lat())
+    );
+    const shell = new LinearRing(List(coords));
+    const polygon = new Polygon(shell, List());
+    const loi = new LocationOfInterest(
+      id,
+      jobId,
+      polygon,
+      Map<string, string | number>(),
+      /* customId= */ '',
+      /* predefined= */ false,
+      /* submissionCount= */ 0
+    );
+    await this.dataStore.addOrUpdateLoi(surveyId, loi);
+    return loi;
   }
 
   async updatePoint(_loi: LocationOfInterest): Promise<void> {


### PR DESCRIPTION
Summary
Implements end-to-end polygon drawing on the web app:
- Click map to add vertices with live preview overlay
- Complete/Cancel toolbar appears during drawing
- Saves polygon LOI to Firestore via Protobuf serialization
- Unhides the polygon drawing tool button

Changes
- `geometry-data-converter.ts`: model → Protobuf converters
- `loi-data-converter.ts`: LOI → Firestore document serializer  
- `data-store.service.ts`: `addOrUpdateLoi()` method
- `loi.service.ts`: `addPoint()` updated, `addPolygon()` added
- `map.component`: vertex collection, preview overlay, toolbar UI
- `drawing-tools.component`: polygon button unhidden
- `map.component.spec.ts`: tests updated and added