### PR TITLE
Send one fewer broadcast per created LOI

### DIFF
--- a/functions/src/on-create-loi.ts
+++ b/functions/src/on-create-loi.ts
@@ -20,7 +20,6 @@ import {
 } from 'firebase-functions/v2/firestore';
 import { Datastore } from './common/datastore';
 import { getDatastore } from './common/context';
-import { broadcastSurveyUpdate } from './common/broadcast-survey-update';
 import { GroundProtos } from '@ground/proto';
 import { toDocumentData, toGeoJsonGeometry, toMessage } from '@ground/lib';
 import { toLoiPbProperties } from './import-geojson';
@@ -61,8 +60,6 @@ export async function onCreateLoiHandler(
       new Pb.LocationOfInterest({ properties: toLoiPbProperties(properties) })
     )
   );
-
-  await broadcastSurveyUpdate(surveyId);
 }
 
 export async function regenerateLoiProperties(


### PR DESCRIPTION
part of #2580

onCreateLoi broadcast a survey update explicitly after writing the generated properties back to the document. That write hits the same path template as onWriteLoi, which is registered with onDocumentWritten and broadcasts on its own, so each created LOI triggered three broadcasts where two are enough.